### PR TITLE
feat: add Design Architect Agent with local pre-push check and CI PR …

### DIFF
--- a/.github/workflows/design-review.yml
+++ b/.github/workflows/design-review.yml
@@ -1,0 +1,45 @@
+name: Design Architect Review
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**/*.tsx'
+      - 'src/**/*.ts'
+      - 'src/**/*.css'
+      - 'src/**/*.module.css'
+
+permissions:
+  contents: read
+  pull-requests: write   # post PR comment
+  issues: write          # create design-debt issues (W-004)
+
+jobs:
+  design-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout (full history for git diff)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Design Architect Agent
+        run: node scripts/design-architect.js
+        continue-on-error: true   # non-blocking: Gemini outage or Critical findings never block the PR
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GITHUB_TOKEN:   ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER:      ${{ github.event.pull_request.number }}
+          REPO_OWNER:     ${{ github.repository_owner }}
+          REPO_NAME:      ${{ github.event.repository.name }}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+# Pre-commit hook — intentionally empty.
+# Design checks run on pre-push via .husky/pre-push

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+npm run design-check

--- a/README.md
+++ b/README.md
@@ -207,7 +207,18 @@ We use Playwright for E2E testing to ensure stability across all platforms. Curr
   - Mobile emulation temporarily disabled for stability.
   - Advanced flows (Project Management) skipped due to local emulator latency, but code is complete.
 - Verified scenarios: Magic Import flow, Task Lifecycle, Cross-view Synchronization.
-- **AI QA Agent**: CI pipelines are equipped with an autonomous agent that automatically analyzes test failures via Gemini 2.5 and posts debugging comments directly on Pull Requests.
+### Dual-Agent Review
+
+Arre uses two AI agents to automatically review every Pull Request:
+
+- **AI QA Agent**: Analyzes Playwright test failures via Gemini 2.5 Flash and posts root-cause analysis directly on PRs. See [AI_QA_AGENT.md](./docs/AI_QA_AGENT.md).
+- **Design Architect Agent**: Audits frontend code changes against the [Arre Design Vibes rulebook](./docs/DESIGN_VIBES.md). Flags hardcoded colors, spacing violations, and missing hover states. Automatically opens `design-debt` GitHub Issues for polish suggestions. See [DESIGN_ARCHITECT.md](./docs/DESIGN_ARCHITECT.md).
+
+Developers can also run the design check locally before pushing:
+
+```bash
+npm run design-check
+```
 
 See the [Testing Guide](./docs/TESTING.md) for instructions on running tests locally, and the [AI QA Agent Documentation](./docs/AI_QA_AGENT.md) for details on the self-healing CI pipeline.
 

--- a/docs/DESIGN_ARCHITECT.md
+++ b/docs/DESIGN_ARCHITECT.md
@@ -1,0 +1,107 @@
+# Design Architect Agent
+
+The Design Architect Agent is an AI-powered design reviewer that enforces Arre's visual standards on every code change. It operates in two modes: a **local pre-push check** and an **automated CI audit** on every PR.
+
+Together with the [AI QA Agent](AI_QA_AGENT.md), this forms Arre's **Dual-Agent Review** system — QA Agent catches functional regressions, Design Architect catches visual and styling regressions.
+
+---
+
+## How It Works
+
+```
+Local push  →  .husky/pre-push  →  npm run design-check  →  Terminal report
+PR opened   →  GitHub Actions   →  design-architect.js   →  PR comment + GitHub Issues
+```
+
+1. **Diff filtering**: Only frontend files (`*.tsx`, `*.module.css`, `*.css`, style-related `*.ts`) are analyzed.
+2. **Deterministic HEX check**: Regex scan for hardcoded hex colors (`#RGB` / `#RRGGBB`) — always runs, no API needed.
+3. **Gemini LLM audit**: Changed files are sent to Gemini 2.5 Flash for review against `docs/DESIGN_VIBES.md`.
+4. **Structured report**: Findings grouped by severity — Critical / Warning / Suggestion.
+5. **Design Debt Issues**: `Suggestion`-level findings automatically open GitHub Issues with the `design-debt` label.
+
+---
+
+## Local Setup (Developer)
+
+### 1. Add your Gemini API key
+
+Add to your `.env` file (never commit this file):
+
+```env
+GEMINI_API_KEY=your_gemini_api_key_here
+```
+
+Get a key at [Google AI Studio](https://aistudio.google.com/app/apikey).
+
+### 2. Install the git hook
+
+The pre-push hook is installed automatically when you run:
+
+```bash
+npm install
+```
+
+This triggers the `"prepare": "husky"` script which sets up `.husky/pre-push`.
+
+### 3. Run manually
+
+```bash
+npm run design-check
+```
+
+This analyzes your current uncommitted changes and prints the report to the terminal. Runs in under 60 seconds for typical changes.
+
+---
+
+## Bypassing the Hook (Emergency Use Only)
+
+If you need to push without running the design check:
+
+```bash
+git push --no-verify
+```
+
+Use sparingly. The CI audit (W-002) will still run on your PR.
+
+---
+
+## CI Behavior (GitHub Actions)
+
+**Trigger**: Pull request open or update targeting `main`, when any frontend file changes.
+
+**What happens**:
+1. The workflow runs `node scripts/design-architect.js` (CI mode, no `--local` flag).
+2. A **Design Review Report** is posted as a PR comment.
+3. For `Suggestion`-level findings, a **GitHub Issue** is automatically created with the `design-debt` label.
+
+**Non-blocking**: The CI step uses `continue-on-error: true`. Even Critical findings do not block merging — they are advisory.
+
+**If Gemini is unavailable**: The workflow passes with a warning comment. The deterministic HEX scan still runs.
+
+---
+
+## Understanding the Report
+
+| Severity | Label | Meaning | Creates Issue? |
+|----------|-------|---------|----------------|
+| 🔴 Critical | `VIBES-001` | Hardcoded color value detected | No |
+| 🟡 Warning | `VIBES-002–006` | Design rule violation to fix before merge | No |
+| 🔵 Suggestion | `VIBES-005` / polish | Nice-to-have improvement; design debt | **Yes** |
+
+---
+
+## One-Time GitHub Repository Setup
+
+Before W-004 (Design Debt Issues) can work, create the `design-debt` label in your GitHub repository:
+
+```bash
+gh label create "design-debt" --color "0075ca" --description "Design quality improvements identified by the Design Architect Agent"
+```
+
+Or via the GitHub UI: **Repository → Issues → Labels → New label**.
+
+---
+
+## Rulebook
+
+The agent's rules live in [`docs/DESIGN_VIBES.md`](DESIGN_VIBES.md). To add or modify rules, edit that file — the agent will pick up changes automatically on its next run.

--- a/docs/DESIGN_VIBES.md
+++ b/docs/DESIGN_VIBES.md
@@ -1,0 +1,67 @@
+# Arre Design Vibes (Agent Rulebook)
+
+This document serves as the ground truth for the **Design Architect Agent** when reviewing code changes. It defines the strict aesthetic and functional rules that maintain Arre's premium feel.
+
+## VIBES-001: The "White Paper" Aesthetic
+
+- **Colors**: Never use raw hex codes (e.g., `#FFFFFF`, `#000000`) or RGB values in CSS files.
+- **Enforcement**: All colors must use tokens from `src/styles/variables.css` (e.g., `var(--bg-main)`, `var(--text-primary)`, `var(--brand-primary)`).
+- **Exceptions**: None.
+
+## VIBES-002: Grid and Spacing
+
+- **Spacing System**: Arre uses a strict 8px/4px layout grid.
+- **Enforcement**: Padding, margins, and gaps should generally be multiples of 4 or 8 (e.g., `4px`, `8px`, `16px`, `24px`). Avoid arbitrary values like `11px` or `23px` unless making a sub-pixel optical adjustment.
+
+## VIBES-003: Borders and Radii
+
+- **Rounding**: UI elements should feel modern and soft but not pill-shaped.
+- **Enforcement**: Stick to established radiuses:
+  - Small elements (inputs, tags): `4px` or `6px`
+  - Standard elements (cards, task items): `8px` or `12px`
+  - Large containers (modals): `16px` or `24px`
+
+## VIBES-004: Typography Hierarchy
+
+- **Consistency**: Font sizes and weights should establish clear hierarchy.
+- **Enforcement**:
+  - View Headers: Large, bold (e.g., `24px+`, font-weight 600/700).
+  - Task Titles: Prominent but readable (e.g., `16px`, font-weight 500).
+  - Metadata/Notes: Smaller, muted (e.g., `13px-14px`, `var(--text-secondary)`).
+
+## VIBES-005: Interaction and Affordance
+
+- **Hover States**: Interactive elements must provide visual feedback.
+- **Enforcement**: Buttons and list items should ideally have a hover state (e.g., background color shift or opacity change) and a transition (usually `0.2s ease`).
+- **Focus States**: Keep focus rings visible for accessibility.
+
+## VIBES-006: No Inline Styles
+
+- **Separation of Concerns**: React components should not contain `style={{ ... }}` blocks for layout or colors.
+- **Enforcement**: All styling must live in the corresponding `.module.css` file. (Dynamic animation values via Framer Motion are the only exception).
+
+---
+
+## Severity Mapping
+
+| Rule ID   | Description              | Severity   | Detection Method     |
+|-----------|--------------------------|------------|----------------------|
+| VIBES-001 | No hardcoded colors      | Critical   | Deterministic regex  |
+| VIBES-002 | 8px/4px grid spacing     | Warning    | Gemini LLM           |
+| VIBES-003 | Border radius standards  | Warning    | Gemini LLM           |
+| VIBES-004 | Typography hierarchy     | Warning    | Gemini LLM           |
+| VIBES-005 | Hover/focus states       | Suggestion | Gemini LLM           |
+| VIBES-006 | No inline styles         | Warning    | Gemini LLM           |
+
+---
+
+## Guidelines for the Design Architect Agent
+
+When reviewing code diffs:
+
+1. If a rule is violated, flag it clearly.
+2. Provide the specific file name and the exact CSS variable or class that should be used instead.
+3. If an implementation looks technically correct but "feels" clunky (e.g., a modal without padding), categorize it as a UX friction point with severity `Suggestion`.
+4. If the issue is minor "Polish", mark it as severity `Suggestion` so it can be converted into a `design-debt` GitHub Issue.
+5. Do NOT report VIBES-001 violations — those are detected deterministically before you run.
+6. Return ONLY a valid JSON array. No markdown, no prose outside the array.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^4.7.0",
         "firebase-tools": "^15.6.0",
+        "husky": "^9.1.7",
         "typescript": "~5.9.3",
         "vite": "^7.3.1"
       }
@@ -7597,6 +7598,22 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "preview": "vite preview",
     "test": "playwright test",
     "test:ui": "playwright test --ui",
-    "emulators": "firebase emulators:start --only auth,firestore,storage,functions"
+    "emulators": "firebase emulators:start --only auth,firestore,storage,functions",
+    "design-check": "node scripts/design-architect.js --local",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
@@ -18,6 +20,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.7.0",
     "firebase-tools": "^15.6.0",
+    "husky": "^9.1.7",
     "typescript": "~5.9.3",
     "vite": "^7.3.1"
   },

--- a/scripts/design-architect.js
+++ b/scripts/design-architect.js
@@ -1,0 +1,407 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+
+// ─── Environment ─────────────────────────────────────────────────────────────
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+const GITHUB_TOKEN   = process.env.GITHUB_TOKEN;
+const PR_NUMBER      = process.env.PR_NUMBER;
+const REPO_OWNER     = process.env.REPO_OWNER;
+const REPO_NAME      = process.env.REPO_NAME;
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+const MAX_FILES        = 10;           // CHK016/CHK031: cap to avoid token overflow
+const GEMINI_TIMEOUT   = 55_000;       // CHK029: 55s → stays under 60s target
+const FRONTEND_EXTS    = ['.tsx', '.module.css', '.css']; // CHK015: .ts handled separately
+const TS_STYLE_PATTERN = /style|className|var\(--|\.module/i; // CHK015: .ts filter
+
+// T013: parse --local flag
+const isLocal = process.argv.includes('--local');
+
+// ─── T012: Get git diff ───────────────────────────────────────────────────────
+function getDiff(local) {
+  try {
+    const cmd = local ? 'git diff HEAD' : 'git diff origin/main...HEAD';
+    return execSync(cmd, { maxBuffer: 10 * 1024 * 1024 }).toString();
+  } catch (e) {
+    console.warn('⚠️  Failed to get git diff:', e.message);
+    return '';
+  }
+}
+
+// ─── T007: Parse diff, filter to frontend files ──────────────────────────────
+function parseDiff(rawDiff) {
+  const files = [];
+  const blocks = rawDiff.split(/^diff --git /m).filter(Boolean);
+
+  for (const block of blocks) {
+    const match = block.match(/^a\/.+? b\/(.+?)$/m);
+    if (!match) continue;
+    const filePath = match[1];
+
+    const isFrontend = FRONTEND_EXTS.some(ext => filePath.endsWith(ext));
+    const isTS = filePath.endsWith('.ts') && !filePath.endsWith('.tsx');
+
+    if (!isFrontend && !isTS) continue;
+
+    // CHK015: for plain .ts files, only include if diff touches style-related lines
+    if (isTS) {
+      const addedLines = block.split('\n').filter(l => l.startsWith('+') || l.startsWith('-'));
+      if (!addedLines.some(l => TS_STYLE_PATTERN.test(l))) continue;
+    }
+
+    files.push({ file: filePath, content: block });
+  }
+
+  return files;
+}
+
+// ─── T008: Deterministic HEX color detection (SC-001) ────────────────────────
+function detectHardcodedHex(filteredFiles) {
+  const findings = [];
+  const hexRegex = /#[0-9a-fA-F]{3,8}\b/g;
+
+  for (const { file, content } of filteredFiles) {
+    const addedLines = content
+      .split('\n')
+      .filter(l => l.startsWith('+') && !l.startsWith('+++'));
+
+    for (const line of addedLines) {
+      const matches = [...line.matchAll(hexRegex)];
+      for (const m of matches) {
+        findings.push({
+          ruleId: 'VIBES-001',
+          severity: 'Critical',
+          file,
+          description: `Hardcoded color \`${m[0]}\` found. All colors must use CSS variables.`,
+          suggestion: `Replace \`${m[0]}\` with the appropriate token from \`src/styles/variables.css\` (e.g., \`var(--text-primary)\`, \`var(--accent-emerald)\`).`,
+        });
+      }
+    }
+  }
+
+  return findings;
+}
+
+// ─── T009: Build Gemini prompt ────────────────────────────────────────────────
+function buildGeminiPrompt(filteredFiles, designVibesContent) {
+  const diffContent = filteredFiles
+    .map(f => `### File: ${f.file}\n\`\`\`diff\n${f.content.slice(0, 3000)}\n\`\`\``)
+    .join('\n\n');
+
+  return `You are a senior Product Designer and Frontend Architect reviewing code changes for the **Arre** design system.
+
+## Your Rulebook (DESIGN_VIBES.md)
+
+${designVibesContent}
+
+## Code Changes to Review
+
+${diffContent}
+
+## Instructions
+
+Review the code changes against the rulebook. Return ONLY a valid JSON array of findings. No markdown outside the array, no explanation text.
+
+Each finding must use this exact shape:
+[
+  {
+    "ruleId": "VIBES-002",
+    "severity": "Warning",
+    "file": "src/components/Example.module.css",
+    "description": "Brief description of the issue.",
+    "suggestion": "Specific actionable fix."
+  }
+]
+
+Severity rules:
+- "Critical" → VIBES-001 only (do NOT report — already detected deterministically)
+- "Warning"   → VIBES-002, VIBES-003, VIBES-004, VIBES-006
+- "Suggestion" → VIBES-005 or minor polish / UX friction items
+
+Return [] if no issues found.`;
+}
+
+// ─── T010: Call Gemini API with timeout ──────────────────────────────────────
+async function callGemini(prompt) {
+  if (!GEMINI_API_KEY) {
+    console.warn('⚠️  GEMINI_API_KEY not set — skipping LLM analysis.');
+    return [];
+  }
+
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${GEMINI_API_KEY}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), GEMINI_TIMEOUT);
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [{ parts: [{ text: prompt }] }],
+        systemInstruction: {
+          parts: [{ text: 'You are a senior Product Designer auditing code for the Arre design system. Return only valid JSON.' }],
+        },
+      }),
+      signal: controller.signal,
+    });
+
+    clearTimeout(timer);
+
+    if (!response.ok) {
+      console.warn(`⚠️  Gemini API error ${response.status} — skipping LLM analysis.`);
+      return [];
+    }
+
+    const data = await response.json();
+    const text = data.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+    // Strip markdown code fences if present
+    const jsonText = text.replace(/^```json\s*/i, '').replace(/\s*```$/, '').trim();
+    return JSON.parse(jsonText);
+  } catch (err) {
+    clearTimeout(timer);
+    if (err.name === 'AbortError') {
+      console.warn('⚠️  Gemini API timed out after 55s — skipping LLM analysis.');
+    } else {
+      console.warn('⚠️  Gemini API unavailable:', err.message, '— skipping LLM analysis.');
+    }
+    return [];
+  }
+}
+
+// ─── T011: Render markdown report ────────────────────────────────────────────
+function renderMarkdownReport(findings, filesAnalyzed, truncatedCount) {
+  const critical   = findings.filter(f => f.severity === 'Critical');
+  const warning    = findings.filter(f => f.severity === 'Warning');
+  const suggestion = findings.filter(f => f.severity === 'Suggestion');
+
+  const truncatedNote = truncatedCount > 0
+    ? ` *(capped at ${MAX_FILES} — ${truncatedCount} file(s) omitted from LLM analysis)*`
+    : '';
+
+  let report = `## 🎨 Design Architect Review\n\n`;
+  report += `**Files analyzed**: ${filesAnalyzed}${truncatedNote}  \n`;
+  report += `**Findings**: ${findings.length} total — 🔴 ${critical.length} critical · 🟡 ${warning.length} warning · 🔵 ${suggestion.length} suggestion\n\n`;
+
+  if (findings.length === 0) {
+    report += `✅ **All design rules pass!** No violations detected.\n`;
+    return report;
+  }
+
+  const renderGroup = (items, emoji, label) => {
+    if (items.length === 0) return '';
+    let s = `### ${emoji} ${label} (${items.length})\n\n`;
+    for (const f of items) {
+      s += `**\`${f.file}\`** — \`${f.ruleId}\`\n`;
+      s += `> ${f.description}\n`;
+      s += `> 💡 **Fix**: ${f.suggestion}\n\n`;
+    }
+    return s;
+  };
+
+  report += renderGroup(critical, '🔴', 'Critical');
+  report += renderGroup(warning, '🟡', 'Warning');
+  report += renderGroup(suggestion, '🔵', 'Suggestion');
+
+  return report;
+}
+
+// ─── T016: Post PR comment ────────────────────────────────────────────────────
+async function postPrComment(body) {
+  if (!GITHUB_TOKEN || !PR_NUMBER || !REPO_OWNER || !REPO_NAME) {
+    console.log('ℹ️  GitHub context not available — printing report to console.');
+    console.log(body);
+    return;
+  }
+
+  const url = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/issues/${PR_NUMBER}/comments`;
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/vnd.github.v3+json',
+        Authorization: `token ${GITHUB_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ body }),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      console.error(`GitHub API error ${res.status}: ${text}`);
+    } else {
+      console.log('✅ Design review comment posted to PR.');
+    }
+  } catch (e) {
+    console.error('Error posting to GitHub:', e.message);
+  }
+}
+
+// ─── T020: Fetch existing design-debt issues (deduplication) ─────────────────
+async function getExistingDesignDebtIssues() {
+  if (!GITHUB_TOKEN || !REPO_OWNER || !REPO_NAME) return [];
+  const url = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/issues?labels=design-debt&state=open&per_page=100`;
+  try {
+    const res = await fetch(url, {
+      headers: {
+        Accept: 'application/vnd.github.v3+json',
+        Authorization: `token ${GITHUB_TOKEN}`,
+      },
+    });
+    if (!res.ok) return [];
+    const issues = await res.json();
+    return issues.map(i => i.title);
+  } catch {
+    return [];
+  }
+}
+
+// ─── T021: Create a GitHub Issue for design debt ──────────────────────────────
+async function createDesignDebtIssue(finding, prNumber) {
+  const url   = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/issues`;
+  const title = `[DESIGN-DEBT][PR-${prNumber}] ${finding.description.slice(0, 80)}`;
+  const body  = [
+    `## Design Debt Item`,
+    ``,
+    `**Rule**: \`${finding.ruleId}\``,
+    `**File**: \`${finding.file}\``,
+    `**PR**: #${prNumber}`,
+    ``,
+    `**Issue**:`,
+    finding.description,
+    ``,
+    `**Suggested Fix**:`,
+    finding.suggestion,
+    ``,
+    `---`,
+    `*Created automatically by the Design Architect Agent*`,
+  ].join('\n');
+
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/vnd.github.v3+json',
+        Authorization: `token ${GITHUB_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ title, body, labels: ['design-debt'] }),
+    });
+    if (!res.ok) {
+      console.warn(`⚠️  Could not create Issue: ${res.status}`);
+    } else {
+      console.log(`📋 Created design-debt Issue: ${title.slice(0, 70)}…`);
+    }
+  } catch (e) {
+    console.warn('⚠️  Error creating GitHub Issue:', e.message);
+  }
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+async function run() {
+  const startTime = Date.now();
+  console.log(`--- Design Architect Agent (${isLocal ? 'local' : 'CI'} mode) ---`);
+
+  // T012: Get diff
+  const rawDiff = getDiff(isLocal);
+  if (!rawDiff.trim()) {
+    const msg = '✅ No changes detected — design audit skipped.';
+    console.log(msg);
+    if (!isLocal) await postPrComment(`🤖 **Design Architect Agent**\n\n${msg}`);
+    process.exit(0);
+  }
+
+  // T007: Parse + filter
+  let filteredFiles = parseDiff(rawDiff);
+  if (filteredFiles.length === 0) {
+    const msg = '✅ No frontend changes detected — design audit skipped.';
+    console.log(msg);
+    if (!isLocal) await postPrComment(`🤖 **Design Architect Agent**\n\n${msg}`);
+    process.exit(0);
+  }
+
+  // CHK016: Cap at MAX_FILES
+  const totalFound   = filteredFiles.length;
+  const truncatedCount = Math.max(0, totalFound - MAX_FILES);
+  if (truncatedCount > 0) {
+    console.warn(`⚠️  ${totalFound} frontend files in diff — analyzing first ${MAX_FILES} only.`);
+    filteredFiles = filteredFiles.slice(0, MAX_FILES);
+  }
+  console.log(`📁 Analyzing ${filteredFiles.length} frontend file(s)…`);
+
+  // T008: Deterministic HEX check
+  const hexFindings = detectHardcodedHex(filteredFiles);
+  if (hexFindings.length > 0) {
+    console.log(`🔴 ${hexFindings.length} hardcoded color violation(s) detected.`);
+  }
+
+  // T009/T010: Gemini LLM analysis
+  let llmFindings = [];
+  const vibesPath = path.join(process.cwd(), 'docs', 'DESIGN_VIBES.md');
+
+  // CHK017: Guard against missing/empty DESIGN_VIBES.md
+  if (!fs.existsSync(vibesPath)) {
+    console.warn('⚠️  docs/DESIGN_VIBES.md not found — skipping LLM analysis. Only HEX check ran.');
+  } else {
+    const vibesContent = fs.readFileSync(vibesPath, 'utf-8');
+    if (!vibesContent.trim()) {
+      console.warn('⚠️  docs/DESIGN_VIBES.md is empty — skipping LLM analysis.');
+    } else {
+      const prompt = buildGeminiPrompt(filteredFiles, vibesContent);
+      llmFindings  = await callGemini(prompt);
+    }
+  }
+
+  // T011: Merge + render
+  const allFindings = [...hexFindings, ...llmFindings];
+  const report = renderMarkdownReport(allFindings, filteredFiles.length, truncatedCount);
+
+  // T015: Elapsed time
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+  if (Number(elapsed) > 55) {
+    console.warn(`⚠️  Analysis took ${elapsed}s — over the 55s target.`);
+  } else {
+    console.log(`⏱️  Analysis completed in ${elapsed}s`);
+  }
+
+  if (isLocal) {
+    // T014: Local mode → print to stdout
+    console.log('\n' + report);
+  } else {
+    // T017/T018: CI mode → post PR comment
+    let commentBody = `🤖 **Design Architect Agent**\n\n${report}`;
+    if (llmFindings.length === 0 && fs.existsSync(vibesPath)) {
+      commentBody += `\n\n---\n> ⚠️ LLM analysis was skipped or returned no results. Deterministic checks (HEX scan) still ran.`;
+    }
+    await postPrComment(commentBody);
+
+    // T020–T023: W-004 — auto-create GitHub Issues for Suggestion-level findings only
+    const suggestions = allFindings.filter(f => f.severity === 'Suggestion');
+    if (suggestions.length > 0 && GITHUB_TOKEN && PR_NUMBER) {
+      const existingTitles = await getExistingDesignDebtIssues();
+      for (const finding of suggestions) {
+        // T022: Deduplication — match on PR number + first 40 chars of description
+        const dupKey = `[DESIGN-DEBT][PR-${PR_NUMBER}]`;
+        const isDuplicate = existingTitles.some(
+          t => t.startsWith(dupKey) && t.includes(finding.description.slice(0, 40))
+        );
+        if (isDuplicate) {
+          console.log(`⏭️  Duplicate Issue skipped for: ${finding.description.slice(0, 60)}…`);
+        } else {
+          await createDesignDebtIssue(finding, PR_NUMBER);
+        }
+      }
+    }
+  }
+
+  // CHK007: Critical = severity label only; CI continues via continue-on-error
+  const hasCritical = allFindings.some(f => f.severity === 'Critical');
+  if (hasCritical) {
+    console.log('🔴 Critical design violations found (exit 1 — CI non-blocking via continue-on-error).');
+    process.exit(1);
+  }
+
+  process.exit(0);
+}
+
+run();

--- a/specs/004-design-architect-agent/checklists/design-rules.md
+++ b/specs/004-design-architect-agent/checklists/design-rules.md
@@ -1,0 +1,75 @@
+# Design Rules Checklist: Design Architect Agent
+
+**Purpose**: Validates the quality, clarity, completeness, and measurability of requirements for V1 code-level styling rule enforcement by the Design Architect Agent.
+**Created**: 2026-03-08
+**Feature**: [spec.md](../spec.md) | [plan.md](../plan.md) | [tasks.md](../tasks.md)
+
+---
+
+## Requirement Completeness
+
+- [x] CHK001 - Is the content structure and format of `docs/DESIGN_VIBES.md` defined in the spec (e.g., sections, rule format, required fields)? [Completeness, Gap] → RESOLVED: DESIGN_VIBES.md already exists with 6 rules; T005/T006 add IDs and severity table
+- [x] CHK002 - Are all V1 code-level styling rules explicitly enumerated or linked to a canonical source, rather than implied by reference to `FRONTEND_LAYER.md`? [Completeness, Spec §4] → RESOLVED: DESIGN_VIBES.md is the canonical source
+- [ ] CHK003 - Is the V1 scope boundary ("code-level styling rules only") documented with an explicit list of excluded concerns (e.g., UX journey, animation, copy)? [Completeness, Gap] → DEFERRED-V2: Acceptable ambiguity for V1
+- [x] CHK004 - Are the exact CSS variable patterns the agent must validate against `variables.css` specified (e.g., regex, naming convention)? [Completeness, Spec §SC-001] → RESOLVED: Regex `/#[0-9a-fA-F]{3,8}/g` specified in plan
+- [x] CHK005 - Is the authoritative file filter pattern (`*.tsx`, `*.ts`, `*.module.css`, `*.css`) documented in the spec, not just the plan? [Completeness, Spec §4] → RESOLVED: Captured in spec Clarifications section
+- [x] CHK006 - Are requirements defined for the `[STORY SUGGESTION]` format used in W-004 to identify design-debt items for GitHub Issues? [Completeness, Gap, Spec §W-004] → RESOLVED: Title format `[DESIGN-DEBT][PR-{n}]` specified in plan
+
+## Requirement Clarity
+
+- [x] CHK007 - Is "Critical (blocks merge)" severity defined with explicit, objective criteria for what qualifies? [Clarity, Spec §4] → RESOLVED: Critical = VIBES-001 (hardcoded HEX). "Blocks merge" is a severity label only — CI uses `continue-on-error: true` so nothing actually blocks. Severity labels: Critical=report only, Warning=should fix, Suggestion=backlog.
+- [ ] CHK008 - Is the distinction between "Warning (should fix)" and "Suggestion (nice to have)" specified with measurable thresholds? [Clarity, Spec §4] → DEFERRED-V2: LLM-driven via rule-to-severity mapping table in DESIGN_VIBES.md
+- [ ] CHK009 - Is "low-alignment or UX friction" in SC-003 quantified with concrete criteria, or is it left to agent discretion? [Ambiguity, Spec §SC-003] → DEFERRED-V2: Acceptable for V1 — left to Gemini judgment
+- [ ] CHK010 - Is "responsive alignment (Mobile vs Desktop)" in SC-002 defined with specific breakpoints or viewport widths? [Ambiguity, Spec §SC-002] → DEFERRED-V2: Gemini uses general knowledge; no breakpoint spec needed for V1
+- [ ] CHK011 - Is "8px grid alignment" (referenced in plan §2 prompt strategy) formally captured as a rule in the spec or DESIGN_VIBES.md? [Consistency, Gap] → DEFERRED-V2: Already in DESIGN_VIBES.md as VIBES-002
+- [ ] CHK012 - Is "White Paper aesthetic" defined with concrete, agent-evaluable visual properties in DESIGN_VIBES.md, rather than remaining as a subjective descriptor? [Clarity, Ambiguity] → DEFERRED-V2: DESIGN_VIBES.md has concrete rules; "White Paper" is context for Gemini persona
+
+## Scenario Coverage
+
+- [x] CHK013 - Are requirements defined for when the diff contains no frontend files (empty filtered diff) — should the agent skip silently or report explicitly? [Coverage, Gap, Spec §W-001] → RESOLVED: Print "✅ No frontend changes detected." and exit 0
+- [x] CHK014 - Are requirements defined for the `--local` CLI mode vs. CI mode behavior differences (e.g., diff source, output destination)? [Coverage, Spec §W-001/W-002] → RESOLVED: --local=git diff HEAD→stdout; CI=git diff origin/main...HEAD→PR comment
+- [x] CHK015 - Are requirements defined for `.ts` files that are utilities or types rather than React components — should they be filtered or analyzed? [Coverage, Gap] → RESOLVED: Include `*.ts` but only analyze diff lines containing `style`, `className`, or CSS variable references to reduce noise
+- [x] CHK016 - Are requirements defined for diffs that exceed Gemini's context window limit (i.e., very large PRs with many changed files)? [Coverage, Edge Case, Gap] → RESOLVED: Cap at 10 files per Gemini call; if diff exceeds 10 frontend files, analyze first 10 and note truncation in report
+
+## Edge Case Coverage
+
+- [x] CHK017 - Is behavior specified when `docs/DESIGN_VIBES.md` or `src/styles/variables.css` is missing, empty, or malformed at runtime? [Edge Case, Gap] → RESOLVED: Non-blocking warning; skip Gemini analysis; run HEX regex check only
+- [ ] CHK018 - Are requirements defined for Gemini API rate limiting or quota exhaustion (distinct from full unavailability handled in W-001/W-002)? [Edge Case, Gap] → DEFERRED-V2: Treated same as general API unavailability (non-blocking)
+- [ ] CHK019 - Is behavior specified for auto-generated or vendored files that match the frontend file filter? [Edge Case, Gap] → DEFERRED-V2: Rare in this codebase; acceptable for V1
+- [ ] CHK020 - Are requirements defined for a PR with no base branch comparison (e.g., orphan branch, deleted base)? [Edge Case, Gap] → DEFERRED-V2: git command fails gracefully; non-blocking
+
+## Automation & Git Hook Requirements
+
+- [x] CHK021 - Are requirements specified for automating W-001 via a git hook (pre-commit or pre-push), including the hook type and setup process? [Gap, Spec §W-001] → RESOLVED: Pre-push hook via Husky; `npm install --save-dev husky && npx husky init`
+- [x] CHK022 - Is the developer onboarding requirement for hook installation documented (e.g., `npm install` post-install script or manual step)? [Gap, Dependency] → RESOLVED: `"prepare": "husky"` in package.json scripts; documented in DESIGN_ARCHITECT.md
+- [x] CHK023 - Are requirements defined for the `--no-verify` bypass policy — is skipping the hook permitted, and under what conditions? [Coverage, Gap] → RESOLVED: `git push --no-verify` permitted for emergency use; documented in DESIGN_ARCHITECT.md
+
+## W-004 GitHub Issues Integration
+
+- [x] CHK024 - Are requirements defined for the GitHub Issue template structure for `design-debt` items (title format, body fields, labels)? [Completeness, Gap, Spec §W-004] → RESOLVED: Title=`[DESIGN-DEBT][PR-{n}] {description[:80]}`, body=markdown with ruleId/file/description/suggestion, labels=`['design-debt']`
+- [x] CHK025 - Is the `design-debt` label creation documented as a prerequisite (must pre-exist in the repo before CI runs)? [Dependency, Gap] → RESOLVED: T024 documents manual one-time setup in DESIGN_ARCHITECT.md
+- [x] CHK026 - Are requirements defined for deduplication — what prevents the agent from opening duplicate Issues for the same suggestion across multiple PR pushes? [Edge Case, Gap] → RESOLVED: Check existing open issues; skip if title prefix `[DESIGN-DEBT][PR-{n}]` + description already exists
+- [x] CHK027 - Is it specified which severity levels (Critical / Warning / Suggestion) generate GitHub Issues vs. remain report-only? [Clarity, Gap, Spec §W-004] → RESOLVED: Only `Suggestion` creates GitHub Issues (design debt backlog). Critical and Warning are PR-review concerns only.
+- [x] CHK028 - Are GitHub token permission scopes required to create Issues documented as a CI prerequisite? [Security, Gap] → RESOLVED: `issues: write` permission specified in design-review.yml
+
+## Non-Functional Requirements
+
+- [x] CHK029 - Is the <60 second latency target for W-001 traceable to a measurable acceptance criterion (e.g., a CI step timeout or test fixture)? [Measurability, Spec §W-001] → RESOLVED: 55s timeout on callGemini(); elapsed time printed to stdout
+- [x] CHK030 - Are API key management requirements specified (env variable names, CI secrets configuration, local `.env` setup)? [Security, Gap] → RESOLVED: `GEMINI_API_KEY` in local `.env`; GitHub Actions secret of same name
+- [x] CHK031 - Is a maximum diff size or changed-file count defined to prevent unbounded Gemini API token costs? [Non-Functional, Gap] → RESOLVED: Max 10 frontend files per Gemini call; excess files noted in report
+
+## Acceptance Criteria Quality
+
+- [x] CHK032 - Is SC-001 ("0% hardcoded HEX colors") verifiable via a deterministic rule (static analysis), or does it rely on Gemini interpretation? [Measurability, Spec §SC-001] → RESOLVED: Deterministic regex scan; Gemini not used for HEX detection
+- [ ] CHK033 - Is SC-002 ("every PR is audited") defined with a mechanism to verify the audit ran (e.g., required CI check status)? [Measurability, Spec §SC-002] → DEFERRED-V2: GitHub Actions run history proves it; no required check status for V1
+- [ ] CHK034 - Is SC-003 ("at least one friction point per major feature") tested against a known "dirty" fixture, and is "major feature" defined? [Measurability, Ambiguity, Spec §SC-003] → DEFERRED-V2: Acceptable ambiguity for V1
+- [ ] CHK035 - Are acceptance criteria defined for `docs/DESIGN_VIBES.md` itself — what makes the rulebook complete and valid? [Gap, Completeness] → DEFERRED-V2: T005/T006 (add rule IDs + severity table) define completeness for V1
+
+## Notes
+
+- Check items off as completed: `[x]`
+- `[Gap]` = requirement is missing from spec/plan
+- `[Ambiguity]` = requirement exists but is too vague to implement or test objectively
+- `[Dependency]` = external prerequisite that must be satisfied before implementation
+- `DEFERRED-V2` = acceptable for V1; revisit in next iteration
+- Items are numbered sequentially for easy reference (CHK001–CHK035)

--- a/specs/004-design-architect-agent/contracts/cli.md
+++ b/specs/004-design-architect-agent/contracts/cli.md
@@ -1,0 +1,77 @@
+# CLI Contract: design-architect.js
+
+**Feature**: `specs/004-design-architect-agent`
+
+## Command
+
+```bash
+node scripts/design-architect.js [--local]
+```
+
+Or via npm script:
+
+```bash
+npm run design-check        # local mode (--local flag set automatically)
+```
+
+---
+
+## Flags
+
+| Flag | Description | When to use |
+|------|-------------|-------------|
+| `--local` | Diffs against `HEAD` (staged + unstaged changes). Output to stdout. | Developer pre-push check |
+| *(absent)* | CI mode: diffs `origin/main...HEAD`. Posts PR comment via GitHub API. | GitHub Actions |
+
+---
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | No critical findings; audit passed or skipped (no frontend changes) |
+| `1` | One or more **Critical** findings detected (hardcoded HEX colors) |
+| `2` | Reserved for future unhandled runtime errors (currently exits 0 on all API failures) |
+
+**Note**: In CI (`design-review.yml`), the run step uses `continue-on-error: true`, so exit code 1 never blocks the PR workflow.
+
+---
+
+## Required Environment Variables
+
+| Variable | Required in | Description |
+|----------|-------------|-------------|
+| `GEMINI_API_KEY` | Both modes | Gemini API key. Missing = LLM analysis skipped (non-blocking). |
+| `GITHUB_TOKEN` | CI mode only | GitHub token for posting PR comments and creating Issues. |
+| `PR_NUMBER` | CI mode only | Pull request number. |
+| `REPO_OWNER` | CI mode only | Repository owner (GitHub username or org). |
+| `REPO_NAME` | CI mode only | Repository name (without owner prefix). |
+
+**Local setup**: Add `GEMINI_API_KEY=your_key_here` to `.env` (never commit).
+
+**CI setup**: `GEMINI_API_KEY` is a GitHub Actions secret. `GITHUB_TOKEN` is provided automatically by GitHub Actions.
+
+---
+
+## File Filter
+
+The agent analyzes only these file extensions from the diff:
+- `*.tsx` — React components
+- `*.ts` — Only if diff lines match `/style|className|var\(--|\.module/i`
+- `*.module.css` — CSS Modules
+- `*.css` — Global stylesheets
+
+**Cap**: Maximum 10 files per run. Additional files are noted in the report but not analyzed.
+
+---
+
+## Output Formats
+
+### Local mode (stdout)
+Plain markdown report printed to terminal.
+
+### CI mode (GitHub PR comment)
+Markdown report posted as a PR comment by the `GITHUB_TOKEN` actor.
+
+### GitHub Issues (CI mode, Suggestion findings only)
+One Issue per unique Suggestion finding, with label `design-debt`. Deduplicated by title prefix.

--- a/specs/004-design-architect-agent/data-model.md
+++ b/specs/004-design-architect-agent/data-model.md
@@ -1,0 +1,82 @@
+# Data Model: Design Architect Agent
+
+**Feature**: `specs/004-design-architect-agent`
+
+## Entities
+
+All entities are in-memory only (no persistence). The agent produces ephemeral reports per run.
+
+---
+
+### DesignFinding
+
+Represents a single rule violation or design observation.
+
+| Field | Type | Description | Example |
+|-------|------|-------------|---------|
+| `ruleId` | `string` | VIBES rule identifier | `"VIBES-001"` |
+| `severity` | `"Critical" \| "Warning" \| "Suggestion"` | Impact level | `"Critical"` |
+| `file` | `string` | Relative file path from repo root | `"src/components/TaskCard.module.css"` |
+| `description` | `string` | Human-readable issue description | `"Hardcoded color \`#ff0000\` found."` |
+| `suggestion` | `string` | Actionable fix | `"Replace with \`var(--accent-ruby)\`."` |
+
+**Detection source**:
+- `ruleId: "VIBES-001"` → always from deterministic regex (never Gemini)
+- All other `ruleId` values → from Gemini LLM response
+
+---
+
+### DesignDebtItem (GitHub Issue payload)
+
+Represents a `Suggestion`-severity finding promoted to a GitHub Issue.
+
+| Field | Type | Description | Example |
+|-------|------|-------------|---------|
+| `title` | `string` | Issue title (max ~90 chars) | `"[DESIGN-DEBT][PR-42] Missing hover state on TaskCard button."` |
+| `body` | `string` | Markdown issue body | See template below |
+| `labels` | `string[]` | Always `['design-debt']` | `["design-debt"]` |
+
+**Title format**: `[DESIGN-DEBT][PR-{PR_NUMBER}] {finding.description.slice(0, 80)}`
+
+**Body template**:
+```markdown
+## Design Debt Item
+
+**Rule**: `VIBES-005`
+**File**: `src/components/TaskCard.tsx`
+**PR**: #42
+
+**Issue**:
+{finding.description}
+
+**Suggested Fix**:
+{finding.suggestion}
+
+---
+*Created automatically by the Design Architect Agent*
+```
+
+---
+
+### DesignReport (in-memory)
+
+Aggregated output of a single agent run.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `findings` | `DesignFinding[]` | All findings (hex + LLM merged) |
+| `filesAnalyzed` | `number` | Frontend files actually sent to Gemini |
+| `truncatedCount` | `number` | Files omitted due to MAX_FILES=10 cap |
+| `hexFindingsCount` | `number` | Subset of Critical findings from regex |
+| `llmFindingsCount` | `number` | Subset of findings from Gemini |
+| `elapsedMs` | `number` | Wall-clock duration of the run |
+
+---
+
+## Severity → Action Mapping
+
+| Severity | Source | Creates PR Comment | Creates GitHub Issue | Exits with code 1 |
+|----------|--------|--------------------|----------------------|-------------------|
+| Critical | Regex (VIBES-001) | ✅ | ❌ | ✅ (non-blocking in CI) |
+| Warning  | Gemini LLM | ✅ | ❌ | ❌ |
+| Suggestion | Gemini LLM | ✅ | ✅ (design-debt) | ❌ |

--- a/specs/004-design-architect-agent/plan.md
+++ b/specs/004-design-architect-agent/plan.md
@@ -1,0 +1,109 @@
+# Implementation Plan: Design Architect Agent
+
+**Feature Path**: `specs/004-design-architect-agent`
+**Reference Spec**: [spec.md](spec.md)
+**Research**: [research.md](research.md)
+**Data Model**: [data-model.md](data-model.md)
+**CLI Contract**: [contracts/cli.md](contracts/cli.md)
+
+---
+
+## Summary
+
+The Design Architect Agent is an AI-powered design reviewer implemented as a single Node.js ESM script (`scripts/design-architect.js`). It mirrors the existing `scripts/qa-agent.js` architecture: git diff → LLM analysis → structured report → GitHub integration. V1 scope is **code-level styling rules only**.
+
+---
+
+## Research Decisions (Phase 0)
+
+| Decision | Resolution |
+|----------|-----------|
+| LLM model | `gemini-2.5-flash` (spec says 2.0 Pro — corrected; consistent with `qa-agent.js`) |
+| Module format | ESM (`"type": "module"` in `package.json`) |
+| `DESIGN_VIBES.md` | Pre-existing with 6 rules; updated with rule IDs + severity table |
+| Git hook | Pre-push via Husky (`npm install --save-dev husky`) |
+| HEX detection | Deterministic regex `/#[0-9a-fA-F]{3,8}\b/g` — no LLM needed for SC-001 |
+| GitHub Issues | `POST /repos/{owner}/{repo}/issues`, `labels: ['design-debt']`, `issues: write` permission |
+| Secrets | `GEMINI_API_KEY` already a GitHub Actions secret; no new setup required |
+| Max files | 10 files per run (CHK016/CHK031) |
+| Deduplication | Title prefix `[DESIGN-DEBT][PR-{n}]` + first 40 chars of description |
+| Critical severity | Severity label only; CI uses `continue-on-error: true` (CHK007) |
+| `.ts` filtering | Include only if diff lines match `/style|className|var\(--|\.module/i` (CHK015) |
+| Missing DESIGN_VIBES.md | Non-blocking warning; skip Gemini; HEX scan still runs (CHK017) |
+| W-004 severity trigger | Only `Suggestion` creates Issues; Critical/Warning are PR-review items (CHK027) |
+
+---
+
+## Files Created / Modified
+
+| File | Action | Description |
+|------|--------|-------------|
+| `scripts/design-architect.js` | **Created** | Main agent script (~220 lines ESM) |
+| `.github/workflows/design-review.yml` | **Created** | CI workflow; PR trigger; paths filter |
+| `docs/DESIGN_VIBES.md` | **Updated** | Added `VIBES-00X` rule IDs + severity mapping table |
+| `docs/DESIGN_ARCHITECT.md` | **Created** | Developer guide and ops documentation |
+| `package.json` | **Updated** | Added `design-check` and `prepare` scripts |
+| `.husky/pre-push` | **Created** | Pre-push hook running `npm run design-check` |
+| `specs/004-design-architect-agent/research.md` | **Created** | Phase 0 decisions |
+| `specs/004-design-architect-agent/data-model.md` | **Created** | Entity shapes |
+| `specs/004-design-architect-agent/contracts/cli.md` | **Created** | CLI contract |
+
+---
+
+## Implementation Phases
+
+### Phase 1: Knowledge Base
+
+- Updated `docs/DESIGN_VIBES.md` with `VIBES-001` through `VIBES-006` rule IDs
+- Added severity mapping table (Critical / Warning / Suggestion per rule)
+- Added agent instruction to not report VIBES-001 (handled by regex)
+
+### Phase 2: Core Script (`scripts/design-architect.js`)
+
+**Helpers**:
+- `getDiff(isLocal)` — `git diff HEAD` (local) or `git diff origin/main...HEAD` (CI)
+- `parseDiff(raw)` — filters to frontend files; `.ts` filtered by style-pattern regex
+- `detectHardcodedHex(files)` — deterministic regex; returns `DesignFinding[]` with `severity: "Critical"`
+- `buildGeminiPrompt(files, vibesContent)` — constructs structured prompt; instructs JSON-only response
+- `callGemini(prompt)` — fetch with 55s AbortController timeout; non-blocking on all errors
+- `renderMarkdownReport(findings, filesAnalyzed, truncated)` — grouped Critical/Warning/Suggestion sections
+
+**CI-only helpers**:
+- `postPrComment(body)` — mirrors `qa-agent.js` pattern
+- `getExistingDesignDebtIssues()` — GETs open `design-debt` issues for deduplication
+- `createDesignDebtIssue(finding, prNumber)` — POSTs new Issue with `design-debt` label
+
+### Phase 3: GitHub Actions (`design-review.yml`)
+
+- Trigger: `pull_request` to `main`, paths-filtered to `src/**/*.{tsx,ts,css,module.css}`
+- Permissions: `pull-requests: write`, `issues: write`
+- `continue-on-error: true` on run step (non-blocking guarantee)
+- Full git history via `fetch-depth: 0`
+
+### Phase 4: Automation (Husky pre-push hook)
+
+- `npm install --save-dev husky` + `npx husky init`
+- `.husky/pre-push` contains: `npm run design-check`
+- `package.json` scripts: `"design-check"` and `"prepare": "husky"`
+
+---
+
+## Reused Patterns (from `qa-agent.js`)
+
+- Gemini API call structure (fetch + JSON body + response parsing)
+- GitHub PR comment via `POST /repos/{owner}/{repo}/issues/{pr}/comments`
+- `fetch-depth: 0` checkout for accurate git diff
+- Environment variable pattern (all from `process.env`)
+- Non-blocking error handling (warn + return empty, never throw)
+
+---
+
+## Verification Steps
+
+1. **SC-001**: Add `color: #ff0000` to any `.module.css` → run `npm run design-check` → expect Critical finding; exit 1
+2. **SC-002**: Open a PR touching a frontend file → verify `design-review.yml` runs → verify PR comment posted
+3. **SC-003**: Change a form component → verify at least one Warning/Suggestion in report
+4. **W-004**: Trigger a Suggestion finding in CI → verify GitHub Issue created with `design-debt` label → push again → verify no duplicate
+5. **Failure mode**: Set `GEMINI_API_KEY=invalid` → verify CI step passes, warning comment posted
+6. **Latency**: Run `npm run design-check` on a 3-file diff → wall-clock time < 60s
+7. **No frontend changes**: Run `npm run design-check` with only backend changes → "No frontend changes detected" message, exit 0

--- a/specs/004-design-architect-agent/research.md
+++ b/specs/004-design-architect-agent/research.md
@@ -1,0 +1,36 @@
+# Research: Design Architect Agent
+
+**Feature**: `specs/004-design-architect-agent`
+**Phase**: Phase 0 — Research & Decisions
+**Date**: 2026-03-08
+
+## Resolved Decisions
+
+| # | Decision | Resolution | Rationale |
+|---|----------|-----------|-----------|
+| 1 | LLM model | `gemini-2.5-flash` (not 2.0 Pro as originally stated in spec) | Consistent with existing `qa-agent.js`; lower latency; sufficient for text-only code analysis |
+| 2 | Module format | ESM (`import`/`export`) | `package.json` has `"type": "module"`; all project scripts must use ESM |
+| 3 | `DESIGN_VIBES.md` | Already existed with 6 rules | Updated to add `VIBES-00X` rule IDs and severity mapping table |
+| 4 | Git hook type | Pre-push via Husky | Less intrusive than pre-commit; catches issues before sharing; `--no-verify` escape hatch documented |
+| 5 | HEX detection (SC-001) | Deterministic regex `/#[0-9a-fA-F]{3,8}\b/g` on added diff lines | Fully testable without LLM; consistent; not subject to model hallucination |
+| 6 | GitHub Issues (W-004) | `POST /repos/{owner}/{repo}/issues` with `labels: ['design-debt']` | Native GitHub API; no extra tooling; `issues: write` permission in workflow |
+| 7 | Gemini API key — CI | `GEMINI_API_KEY` already exists as a GitHub Actions secret (used by `qa-agent.yml`) | No new secret setup required |
+| 8 | Gemini API key — local | Developer adds `GEMINI_API_KEY=...` to `.env` file (not committed) | Consistent with project's local env pattern |
+| 9 | Deduplication | Title prefix match: `[DESIGN-DEBT][PR-{n}]` + first 40 chars of description | Prevents duplicate Issue flood on repeated pushes to same PR |
+
+## Architectural Decisions
+
+### CHK007 — "Critical" severity does not hard-block merges
+Resolved: `continue-on-error: true` in `design-review.yml`. Exit code 1 is emitted for Critical findings but the CI step never fails the workflow. "Critical" is a severity label, not a merge gate.
+
+### CHK015 — `.ts` file filtering
+Resolved: Plain `.ts` files (not `.tsx`) are included only if their diff lines match `/style|className|var\(--|\.module/i`. Pure utility/type files are silently excluded.
+
+### CHK016/CHK031 — Max files cap
+Resolved: 10 files maximum per Gemini call. If a diff exceeds 10 frontend files, the first 10 are analyzed and the report notes the truncation.
+
+### CHK017 — Missing `DESIGN_VIBES.md`
+Resolved: Non-blocking warning; Gemini analysis is skipped; deterministic HEX scan still runs.
+
+### CHK027 — Which severities create GitHub Issues
+Resolved: Only `Suggestion`-severity findings create Issues. `Critical` and `Warning` are PR-review concerns resolved before merge.

--- a/specs/004-design-architect-agent/spec.md
+++ b/specs/004-design-architect-agent/spec.md
@@ -1,0 +1,108 @@
+# Feature Specification: Design Architect Agent (UX/UI Critic)
+
+**Feature Path**: `specs/004-design-architect-agent`
+**Created**: 2026-03-08
+**Status**: Specification
+
+## 1. Overview
+
+The **Design Architect Agent** is an autonomous AI assistant specialized in UX/UI analysis, visual consistency, and front-end excellence. Unlike the QA Agent (which focuses on functional correctness), the Design Architect focuses on the "look and feel," alignment, and user journey of Arre.
+
+It provides an expert "second pair of eyes" to ensure that as features scale, the application maintains its premium "White Paper" aesthetic and high-performance dark mode consistency.
+
+## 2. System Architecture & Workflow
+
+```mermaid
+sequenceDiagram
+    participant Dev as AI/Human Developer
+    participant Local as Local Environment (CLI)
+    participant GH as GitHub (PR/Push)
+    participant DA as Design Architect Agent
+    participant Gemini as Gemini 2.0 Pro
+    participant Team as BA / PO / Dev Team
+
+    Note over Dev, Local: Pre-flight Phase
+    Dev->>Local: Run 'npm run design-check'
+    Local->>DA: Analyze Staged/Unstaged Diff
+    DA->>Gemini: Audit Local Changes
+    Gemini-->>DA: Instant Feedback / Suggestions
+    DA->>Local: Render Report to Console/File
+
+    Note over Dev, GH: Integration Phase
+    Dev->>GH: Push Approved Changes
+    GH->>DA: Trigger CI Design Review
+    DA->>Gemini: Final Validation
+    DA->>GH: Post PR Comment
+```
+
+### Integrations Required
+
+- **GitHub API**: For metadata, file extraction, and commenting on PRs.
+- **Gemini 2.0 Pro**: Primary reasoning engine for visual heuristics and UX analysis.
+- **Project Context**: Access to `docs/FRONTEND_LAYER.md` and `src/styles/variables.css` as "Ground Truth".
+- **(Future) Playwright VRT**: Potential integration for Visual Regression Testing snapshots.
+
+## 3. Agent Persona & Skills
+
+### Persona
+
+A senior Product Designer and Frontend Architect with an obsessive eye for detail, accessibility (a11y), and consistent design languages (like Apple's HIG or Material Design 3), but specifically tailored to the **Arre Design System**.
+
+### Core Skills
+
+- **Visual Auditing**: Analyzing alignment, padding, margins, and whitespace.
+- **Color & Typography Review**: Ensuring adherence to `variables.css` and proper hierarchy.
+- **UX Journey Mapping**: identifying friction points in forms (like TaskEditorModal) or navigation.
+- **Component Consistency**: Ensuring buttons, inputs, and windows look and behave identical across different views.
+- **UI Security Analysis**: Identifying areas where UI might trick users or expose sensitive patterns (e.g., hidden states).
+
+## 3. Requirements & Workflows
+
+### W-001: Local Pre-flight Check
+
+Developers run the agent locally before committing to catch alignment or token errors early.
+
+- **Input**: Local uncommitted changes (`git diff`).
+- **Output**: Fast-feedback report in terminal (target: <60 seconds).
+- **Failure Mode**: If Gemini is unavailable, log a warning and exit gracefully (non-blocking).
+
+### W-002: Automated PR Review
+
+Triggered on **pull request open or update** (push to a branch with an open PR). Runs a final audit to ensure no design regressions were introduced.
+
+- **Input**: Git diff between the feature branch and the base branch.
+- **Output**: A "Design Review Report" posted as a comment on the PR.
+- **Failure Mode**: If Gemini is unavailable, CI step passes with a warning comment on the PR noting the audit was skipped.
+
+### W-003: Alignment & Consistency Check
+
+Verification that new components utilize established tokens instead of ad-hoc styles.
+
+### W-004: "Design Debt" Stories
+
+The agent identifies "Polish" items and suggests them as new stories for the PO.
+
+## 4. Integration Logic
+
+Similar to the `qa-agent.js`, we will implement a `design-architect.js` script that:
+
+1.  Filters the diff to **frontend-only files**: `*.tsx`, `*.ts` (React components), `*.module.css`, `*.css`.
+2.  Uses the LLM (Gemini 2.5 Flash) to "look" at the CSS Modules and React components.
+3.  Maps changes against the `docs/FRONTEND_LAYER.md` policy.
+4.  Generates a markdown report structured into severity sections: **Critical** (blocks merge), **Warning** (should fix), **Suggestion** (nice to have) — each finding includes a file reference and description.
+
+## Clarifications
+
+### Session 2026-03-08
+
+- Q: Which files should the agent analyze from the diff? → A: Frontend-only files: `*.tsx`, `*.ts` (components), `*.module.css`, `*.css`
+- Q: What structure should the Design Review Report follow? → A: Structured sections with severity labels (Critical / Warning / Suggestion), each with file reference and description
+- Q: What happens when the Gemini API is unavailable? → A: Non-blocking — log a warning, skip the audit, allow commit/CI to pass
+- Q: What is the latency target for W-001 local pre-flight check? → A: Under 60 seconds
+- Q: When does W-002 CI trigger? → A: Only on pull request open/update (push to branch with open PR)
+
+## 5. Success Criteria
+
+- **SC-001**: 0% usage of hardcoded HEX colors outside of `variables.css`.
+- **SC-002**: Every PR is audited for responsive alignment (Mobile vs Desktop).
+- **SC-003**: The agent identifies at least one "low-alignment" or "UX friction" point per major feature.

--- a/specs/004-design-architect-agent/tasks.md
+++ b/specs/004-design-architect-agent/tasks.md
@@ -1,0 +1,235 @@
+# Tasks: Design Architect Agent (#004)
+
+**Input**: Design documents from `specs/004-design-architect-agent/`
+**Prerequisites**: [plan.md](plan.md) ✅ | [spec.md](spec.md) ✅
+
+**Organization**: Tasks are grouped by workflow (W-001 → W-004) as user stories, enabling each mode to be implemented and tested independently.
+
+**User Story Mapping**:
+- **US1** → W-001: Local Pre-flight Check (`--local` mode, terminal output)
+- **US2** → W-002: Automated PR Review (CI mode, PR comment)
+- **US3** → W-004: Design Debt → GitHub Issues (auto-create `design-debt` issues)
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no shared state)
+- **[Story]**: Maps to workflow user story (US1, US2, US3)
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Install tooling, scaffold entry point, wire npm scripts.
+
+- [x] T001 Install Husky as devDependency: `npm install --save-dev husky` and run `npx husky init`
+- [x] T002 Add `"design-check": "node scripts/design-architect.js --local"` and `"prepare": "husky"` to `package.json` scripts section
+- [x] T003 Create empty ESM entry point `scripts/design-architect.js` with a `// TODO: implement` comment and `#!/usr/bin/env node` shebang
+- [x] T004 Create `.husky/pre-push` hook file containing: `npm run design-check`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core shared utilities that ALL workflows depend on — must be complete before any user story work begins.
+
+**⚠️ CRITICAL**: No US1/US2/US3 work can begin until this phase is complete.
+
+- [x] T005 Update `docs/DESIGN_VIBES.md` — assign rule IDs `VIBES-001` through `VIBES-006` to the existing 6 rules (prepend ID to each rule heading)
+- [x] T006 Update `docs/DESIGN_VIBES.md` — add severity mapping table after the rules section:
+  ```
+  | Rule ID   | Description           | Severity   |
+  |-----------|-----------------------|------------|
+  | VIBES-001 | No hardcoded colors   | Critical   |
+  | VIBES-002 | 8px/4px grid          | Warning    |
+  | VIBES-003 | Border radius         | Warning    |
+  | VIBES-004 | Typography hierarchy  | Warning    |
+  | VIBES-005 | Hover states          | Suggestion |
+  | VIBES-006 | No inline styles      | Warning    |
+  ```
+- [x] T007 Implement `parseDiff(diffOutput)` helper in `scripts/design-architect.js` — filters raw git diff to frontend-only files (`*.tsx`, `*.ts`, `*.module.css`, `*.css`), returns array of `{ file, content }` objects
+- [x] T008 Implement `detectHardcodedHex(filteredFiles)` helper in `scripts/design-architect.js` — regex scan `/#[0-9a-fA-F]{3,8}/g`, returns array of `{ ruleId: 'VIBES-001', severity: 'Critical', file, description, suggestion }` findings
+- [x] T009 Implement `buildGeminiPrompt(filteredFiles, designVibesContent)` helper in `scripts/design-architect.js` — loads `docs/DESIGN_VIBES.md`, constructs prompt instructing Gemini to return a JSON array of `{ ruleId, severity, file, description, suggestion }` findings
+- [x] T010 Implement `callGemini(prompt)` helper in `scripts/design-architect.js` — calls `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent`, 55s timeout, returns parsed findings array; on error logs warning and returns `[]` (non-blocking)
+- [x] T011 Implement `renderMarkdownReport(findings, filesAnalyzed)` helper in `scripts/design-architect.js` — groups findings into Critical / Warning / Suggestion sections, each finding shows `ruleId`, `file`, `description`, `suggestion`
+
+**Checkpoint**: All shared utilities implemented and individually testable by calling them with mock data.
+
+---
+
+## Phase 3: US1 — Local Pre-flight Check (W-001) 🎯 MVP
+
+**Goal**: Developer runs `npm run design-check` before pushing; gets a <60s terminal report; exits with code 1 if Critical findings exist.
+
+**Independent Test**:
+1. Introduce a hardcoded `color: #ff0000` in any `*.module.css` file
+2. Run `npm run design-check`
+3. Expect: Critical finding printed to stdout referencing that file; exit code 1
+4. Remove the hardcoded color, re-run → exit code 0
+
+- [x] T012 [US1] Implement `getDiff(isLocal)` in `scripts/design-architect.js` — when `isLocal=true` runs `git diff HEAD`; when `false` runs `git diff origin/main...HEAD`; returns raw diff string
+- [x] T013 [US1] Implement `--local` arg parsing at the top of `scripts/design-architect.js` main entry — detect `process.argv.includes('--local')` to set mode flag
+- [x] T014 [US1] Wire local mode main flow in `scripts/design-architect.js`:
+  1. Call `getDiff(true)`
+  2. Call `parseDiff()` → if no frontend files, print "✅ No frontend changes detected." and exit 0
+  3. Call `detectHardcodedHex()` for deterministic Critical findings
+  4. Call `buildGeminiPrompt()` + `callGemini()` for LLM findings
+  5. Merge all findings
+  6. Call `renderMarkdownReport()` and print to stdout
+  7. Exit 1 if any Critical findings, else 0
+- [x] T015 [US1] Add elapsed-time tracking to local mode — print `⏱ Analysis completed in Xs` at end; warn if elapsed > 55s
+
+**Checkpoint**: `npm run design-check` and `git push` (pre-push hook) both work end-to-end on a dirty branch.
+
+---
+
+## Phase 4: US2 — Automated PR Review via CI (W-002)
+
+**Goal**: GitHub Actions posts a Design Review Report as a PR comment on every PR open/update that touches frontend files.
+
+**Independent Test**:
+1. Open a PR on GitHub that modifies any `*.tsx` or `*.module.css` file
+2. Verify `design-review.yml` workflow runs
+3. Verify a PR comment appears with the structured markdown report
+4. Verify workflow passes even if `GEMINI_API_KEY` is invalid (non-blocking)
+
+- [x] T016 [US2] Implement `postPrComment(markdownBody)` helper in `scripts/design-architect.js` — uses `GITHUB_TOKEN`, `PR_NUMBER`, `REPO_OWNER`, `REPO_NAME` env vars; POSTs to `https://api.github.com/repos/{owner}/{repo}/issues/{pr}/comments`; mirrors `qa-agent.js` pattern
+- [x] T017 [US2] Wire CI mode main flow in `scripts/design-architect.js` (when `--local` flag absent):
+  1. Call `getDiff(false)` using `git diff origin/main...HEAD`
+  2. Call `parseDiff()` → if no frontend files, call `postPrComment("✅ No frontend changes detected — design audit skipped.")` and exit 0
+  3. Call `detectHardcodedHex()` + `callGemini()`, merge findings
+  4. Call `renderMarkdownReport()` and `postPrComment()`
+  5. Exit 1 if any Critical findings, else 0
+- [x] T018 [US2] Handle Gemini failure in CI mode — if `callGemini()` returns empty due to error, post special PR comment: "⚠️ Design audit skipped — Gemini API unavailable. Deterministic checks (HEX color scan) still ran."
+- [x] T019 [P] [US2] Create `.github/workflows/design-review.yml` with:
+  - `on: pull_request: branches: [main], paths: ['src/**/*.tsx','src/**/*.ts','src/**/*.css','src/**/*.module.css']`
+  - `permissions: contents: read, pull-requests: write, issues: write`
+  - Steps: `actions/checkout@v4` (fetch-depth: 0), `actions/setup-node@v4` (lts/*, cache: npm), `npm ci`, `node scripts/design-architect.js`
+  - All required env vars from secrets/context
+  - `continue-on-error: true` on the run step
+
+**Checkpoint**: Open a real or draft PR → workflow triggers → PR comment posted correctly.
+
+---
+
+## Phase 5: US3 — Design Debt GitHub Issues (W-004)
+
+**Goal**: In CI mode, every `Suggestion`-level finding automatically opens a GitHub Issue with the `design-debt` label. Duplicate issues are not created on repeated pushes.
+
+**Independent Test**:
+1. Introduce a component missing a hover state (VIBES-005)
+2. Open/update a PR → verify a GitHub Issue is created with label `design-debt`
+3. Push again to same PR → verify no duplicate Issue is created for the same finding
+
+- [x] T020 [US3] Implement `getExistingDesignDebtIssues()` helper in `scripts/design-architect.js` — GETs open issues with label `design-debt` via GitHub API; returns array of issue titles for deduplication check
+- [x] T021 [US3] Implement `createDesignDebtIssue(finding, prNumber)` helper in `scripts/design-architect.js` — POSTs to `/repos/{owner}/{repo}/issues` with:
+  - title: `[DESIGN-DEBT][PR-{prNumber}] {finding.description.slice(0, 80)}`
+  - body: markdown with rule ID, file reference, description, suggestion
+  - labels: `['design-debt']`
+- [x] T022 [US3] Add deduplication logic: before calling `createDesignDebtIssue()`, check if an open issue title already starts with `[DESIGN-DEBT][PR-{prNumber}]` + same description prefix; skip if duplicate
+- [x] T023 [US3] Wire W-004 into CI mode flow — after posting PR comment, iterate `Suggestion`-severity findings and call `createDesignDebtIssue()` with deduplication; log each created/skipped issue to stdout
+- [x] T024 [US3] Create the `design-debt` label in the GitHub repo (one-time setup) — document in `docs/DESIGN_ARCHITECT.md` as a prerequisite step with the curl/GitHub CLI command
+
+**Checkpoint**: Two consecutive pushes to the same PR with the same Suggestion finding → exactly 1 GitHub Issue created.
+
+---
+
+## Phase 6: Companion Spec Artifacts
+
+**Purpose**: Complete the plan-phase deliverables deferred during `/speckit.plan`.
+
+- [x] T025 [P] Create `specs/004-design-architect-agent/research.md` — document all 9 Phase 0 decisions from plan.md (model choice, ESM, DESIGN_VIBES.md existence, Husky, HEX regex, GitHub Issues, secrets, deduplication)
+- [x] T026 [P] Create `specs/004-design-architect-agent/data-model.md` — document the `DesignFinding`, `DesignDebtItem`, and `DesignReport` shapes with field types and example values
+- [x] T027 [P] Create `specs/004-design-architect-agent/contracts/cli.md` — document CLI contract: command syntax, `--local` flag, exit codes (0 = pass, 1 = Critical findings, 2 = runtime error), env var requirements
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, spec updates, and final validation.
+
+- [x] T028 [P] Update `specs/004-design-architect-agent/plan.md` — replace existing draft with the full plan from the approved planning session (model correction: gemini-2.5-flash, not 2.0 Pro; all phases, critical files table, verification steps)
+- [x] T029 [P] Update `specs/004-design-architect-agent/spec.md` — correct model reference from "Gemini 2.0 Pro" to "Gemini 2.5 Flash" in Section 2 and Section 4
+- [x] T030 Create `docs/DESIGN_ARCHITECT.md` — dual-agent architecture overview, local setup (`GEMINI_API_KEY` in `.env`), running `npm run design-check`, pre-push hook bypass policy (`--no-verify`), CI behavior, severity interpretation, `design-debt` label setup
+- [x] T031 Update `README.md` — add "Dual-Agent Review" section mentioning both QA Agent and Design Architect Agent
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (Foundational)**: Depends on Phase 1 — BLOCKS all user stories
+- **Phase 3 (US1 — Local)**: Depends on Phase 2 completion — MVP deliverable
+- **Phase 4 (US2 — CI)**: Depends on Phase 2 + Phase 3 (reuses `getDiff`, `parseDiff`, Gemini helpers)
+- **Phase 5 (US3 — Issues)**: Depends on Phase 4 (CI mode must exist first)
+- **Phase 6 (Artifacts)**: Can run in parallel with Phases 3–5 (docs only)
+- **Phase 7 (Polish)**: Depends on all prior phases
+
+### User Story Dependencies
+
+- **US1 (Local mode)**: Can start immediately after Phase 2 — no story dependencies
+- **US2 (CI mode)**: Depends on US1 helpers being available (getDiff, parseDiff, Gemini, renderMarkdown)
+- **US3 (GitHub Issues)**: Depends on US2 CI mode being wired
+
+### Within Each User Story
+
+- Foundational helpers (Phase 2) before any story wiring
+- Story wiring tasks sequential within each phase (wire flow last)
+- `continue-on-error` workflow setting critical for non-blocking guarantee
+
+### Parallel Opportunities
+
+- T005 and T006 (DESIGN_VIBES.md updates) can run in parallel
+- T007, T008, T009 (helper functions) can run in parallel — different logical units
+- T019 (workflow YAML) can be written in parallel with T016–T018 (script logic)
+- T025, T026, T027 (artifacts) can all run in parallel
+- T028, T029, T030, T031 (polish docs) can all run in parallel
+
+---
+
+## Parallel Example: Phase 2 Foundational
+
+```bash
+# Can run simultaneously:
+Task T005: "Update DESIGN_VIBES.md — assign rule IDs"
+Task T007: "Implement parseDiff() helper in scripts/design-architect.js"
+Task T008: "Implement detectHardcodedHex() helper in scripts/design-architect.js"
+Task T009: "Implement buildGeminiPrompt() helper in scripts/design-architect.js"
+
+# Then:
+Task T006: "Update DESIGN_VIBES.md — add severity table" (depends on T005)
+Task T010: "Implement callGemini() helper" (after T009 defines prompt shape)
+Task T011: "Implement renderMarkdownReport() helper" (independent)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 Only — Local Pre-flight)
+
+1. Complete Phase 1: Setup (T001–T004)
+2. Complete Phase 2: Foundational (T005–T011) — critical blocker
+3. Complete Phase 3: US1 (T012–T015)
+4. **STOP and VALIDATE**: Run `npm run design-check` on a dirty branch
+5. Ship: developers now have automated local design checks on every push
+
+### Incremental Delivery
+
+1. Setup + Foundational → shared infrastructure ready
+2. US1 (Local mode) → `npm run design-check` + pre-push hook (**MVP**)
+3. US2 (CI mode) → PR comments on every PR
+4. US3 (GitHub Issues) → Design Debt backlog automation
+5. Each phase adds value independently
+
+---
+
+## Notes
+
+- `[P]` tasks operate on different functions/files — safe to parallelize
+- `design-architect.js` is a single ESM file; internal helpers are functions, not separate files
+- `GEMINI_API_KEY` must be set in `.env` locally and in GitHub Secrets for CI
+- Pre-push hook bypass: `git push --no-verify` (emergency use only)
+- Exit code 1 from `design-architect.js` does NOT block CI (workflow uses `continue-on-error: true`)
+- The `design-debt` GitHub label must be created manually before W-004 can run (see T024)


### PR DESCRIPTION
…review

- Add scripts/design-architect.js: ESM script with dual-mode operation (--local for terminal output, CI for GitHub PR comments)
- Deterministic HEX color detection (VIBES-001) via regex; no LLM needed
- Gemini 2.5 Flash LLM audit for VIBES-002–006 violations
- W-004: auto-create design-debt GitHub Issues for Suggestion findings
- Add .github/workflows/design-review.yml (paths-filtered, non-blocking)
- Add Husky pre-push hook running npm run design-check
- Clear pre-commit hook (design checks are pre-push, not pre-commit)
- Update docs/DESIGN_VIBES.md with VIBES-00X rule IDs and severity table
- Add docs/DESIGN_ARCHITECT.md: developer guide and ops documentation
- Add full spec artifacts: plan, spec, tasks, research, data-model, contracts