### PR TITLE
feat: move settings to sidebar footer and add theme selector to setti…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+﻿# arre-app Development Guidelines
+
+Auto-generated from all feature plans. Last updated: 2026-03-08
+
+## Active Technologies
+
+- TypeScript 5.x + React 18 + React Router v6 (Link/useLocation), lucide-react (icons), CSS Modules (001-consolidate-settings)
+
+## Project Structure
+
+```text
+backend/
+frontend/
+tests/
+```
+
+## Commands
+
+npm test; npm run lint
+
+## Code Style
+
+TypeScript 5.x + React 18: Follow standard conventions
+
+## Recent Changes
+
+- 001-consolidate-settings: Added TypeScript 5.x + React 18 + React Router v6 (Link/useLocation), lucide-react (icons), CSS Modules
+
+<!-- MANUAL ADDITIONS START -->
+<!-- MANUAL ADDITIONS END -->

--- a/specs/001-consolidate-settings/checklists/requirements.md
+++ b/specs/001-consolidate-settings/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Consolidate Settings into Sidebar Footer
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/001-consolidate-settings/data-model.md
+++ b/specs/001-consolidate-settings/data-model.md
@@ -1,0 +1,21 @@
+# Data Model: Consolidate Settings into Sidebar Footer
+
+**Branch**: `001-consolidate-settings` | **Date**: 2026-03-08
+
+## Overview
+
+This feature involves no new data entities and no schema changes. It is a pure UI relocation of existing functionality.
+
+## Existing Entity: Theme Preference
+
+| Attribute    | Value                                  |
+|--------------|----------------------------------------|
+| Name         | Theme Preference                       |
+| Storage      | Browser localStorage                   |
+| Key          | `"vite-ui-theme"`                      |
+| Type         | String enum: `'light'` \| `'dark'` \| `'system'` |
+| Default      | `'system'`                             |
+| Managed by   | `src/features/theme/ThemeProvider.tsx` |
+| Changed by   | (before) Sidebar footer button — (after) Settings page Appearance section |
+
+No structural change to this entity. Only the UI control that writes to it changes location.

--- a/specs/001-consolidate-settings/plan.md
+++ b/specs/001-consolidate-settings/plan.md
@@ -1,0 +1,215 @@
+# Implementation Plan: Consolidate Settings into Sidebar Footer
+
+**Branch**: `001-consolidate-settings` | **Date**: 2026-03-08 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/001-consolidate-settings/spec.md`
+
+## Summary
+
+Move the Settings navigation entry from the main sidebar nav list to the sidebar footer (replacing the theme cycle button), and relocate the theme toggle control (Light / Dark / System) into the Settings page as a new "Appearance" section rendered before the existing Integrations section.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x + React 18
+**Primary Dependencies**: React Router v6 (Link/useLocation), lucide-react (icons), CSS Modules
+**Storage**: localStorage (theme preference — no change to storage mechanism)
+**Testing**: Vitest + React Testing Library
+**Target Platform**: Web browser (desktop + mobile responsive)
+**Project Type**: Web application (SPA)
+**Performance Goals**: Theme change visually applies in under 500ms (already met by existing ThemeProvider)
+**Constraints**: No new routes; Settings page URL (`/settings`) must remain unchanged; no backend changes
+
+## Constitution Check
+
+The project constitution file is an unfilled template with no ratified principles. No gates to evaluate.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-consolidate-settings/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output (minimal — no new entities)
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (files modified by this feature)
+
+```text
+src/
+├── layout/
+│   ├── Sidebar.tsx              # Remove Settings from NAV_ITEMS; replace theme button with settings Link
+│   └── Sidebar.module.css       # Rename .settingsButton → .footerLink
+├── pages/
+│   ├── Settings.tsx             # Add Appearance section with theme selector
+│   └── Settings.module.css      # Add theme selector styles
+└── features/
+    └── theme/
+        └── ThemeProvider.tsx    # No changes (read-only dependency)
+```
+
+## Phase 0: Research
+
+Complete. See [research.md](./research.md).
+
+All decisions resolved through codebase analysis:
+- Theme selector: segmented button group (3 explicit options)
+- Footer element: `<Link>` for semantic navigation
+- CSS class: rename `settingsButton` → `footerLink`
+- Section order in Settings: Appearance before Integrations
+- Sidebar cleanup: remove all theme-related logic from Sidebar
+
+## Phase 1: Design & Contracts
+
+### Data Model
+
+No new entities. No schema changes. Theme preference continues to be persisted via the existing `localStorage` key `"vite-ui-theme"` managed by `ThemeProvider`. See [data-model.md](./data-model.md).
+
+### UI Contracts
+
+#### Sidebar Footer — After Change
+
+| Element    | Type  | Target        | Content                  |
+|------------|-------|---------------|--------------------------|
+| footerLink | Link  | `/settings`   | SettingsIcon + "Settings" text |
+
+The footer renders one interactive element (settings link) plus the dev-only `SeedButton`. The theme button is removed entirely.
+
+#### Settings Page — Appearance Section (new)
+
+| Element          | Type           | Values                    | Behavior                               |
+|------------------|----------------|---------------------------|----------------------------------------|
+| Section heading  | `<h2>`         | "Appearance"              | Consistent with "Integrations" heading |
+| Theme selector   | Button group   | Light / Dark / System     | Active option highlighted; click calls `setTheme(value)` |
+| Sun icon         | lucide Sun     | shown in Light button     | 20px, inline                           |
+| Moon icon        | lucide Moon    | shown in Dark button      | 20px, inline                           |
+| Laptop icon      | lucide Laptop  | shown in System button    | 20px, inline                           |
+
+#### Acceptance contract
+
+- Navigating to `/settings` continues to work (no route changes)
+- `data-testid="nav-item-settings"` is removed from sidebar nav
+- A new settings link in the sidebar footer navigates to `/settings`
+- Selecting a theme option in Settings immediately changes `document.documentElement` class (via ThemeProvider)
+- Selected theme option appears visually active (distinct styling from inactive options)
+- Theme persists to `localStorage["vite-ui-theme"]` on every selection
+
+### Implementation Steps
+
+#### Step 1 — Sidebar.tsx: Remove Settings from NAV_ITEMS
+
+Remove the Settings entry from the `NAV_ITEMS` constant (line 17):
+```
+{ path: '/settings', label: 'Settings', icon: SettingsIcon, color: 'text-secondary' }
+```
+
+Also remove unused imports: `Moon`, `Laptop`, `useTheme` (if no longer needed in Sidebar). Remove `cycleTheme`, `ThemeIcon`, `themeLabel` local variables.
+
+Add `import { Link } from 'react-router-dom'` is already imported via `{ Link, useLocation }`.
+
+#### Step 2 — Sidebar.tsx: Replace footer theme button with settings Link
+
+Replace:
+```tsx
+<button className={styles.settingsButton} onClick={cycleTheme} title="Toggle Theme">
+  <ThemeIcon size={20} />
+  <span>{themeLabel} Mode</span>
+</button>
+```
+
+With:
+```tsx
+<Link to="/settings" className={styles.footerLink}>
+  <SettingsIcon size={20} />
+  <span>Settings</span>
+</Link>
+```
+
+`SettingsIcon` is already imported from lucide-react (line 2).
+
+#### Step 3 — Sidebar.module.css: Rename class
+
+Rename `.settingsButton` and `.settingsButton:hover` to `.footerLink` and `.footerLink:hover`. Styles remain identical.
+
+#### Step 4 — Settings.tsx: Add Appearance section
+
+Import `useTheme` from `../features/theme/ThemeProvider` and `Sun, Moon, Laptop` from `lucide-react`.
+
+Add a new `<section className={styles.settingsSection}>` **before** the Integrations section:
+
+```tsx
+<section className={styles.settingsSection}>
+  <h2>Appearance</h2>
+  <div className={styles.themeSelector}>
+    {[
+      { value: 'light', label: 'Light', Icon: Sun },
+      { value: 'dark',  label: 'Dark',  Icon: Moon },
+      { value: 'system',label: 'System',Icon: Laptop },
+    ].map(({ value, label, Icon }) => (
+      <button
+        key={value}
+        className={clsx(styles.themeOption, theme === value && styles.themeOptionActive)}
+        onClick={() => setTheme(value as 'light' | 'dark' | 'system')}
+      >
+        <Icon size={18} />
+        <span>{label}</span>
+      </button>
+    ))}
+  </div>
+</section>
+```
+
+Add `import clsx from 'clsx'` if not already present.
+
+#### Step 5 — Settings.module.css: Add theme selector styles
+
+```css
+.themeSelector {
+  display: flex;
+  gap: var(--spacing-2);
+  background-color: var(--surface-overlay);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-1);
+}
+
+.themeOption {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-4);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-weight: 500;
+  font-size: 0.875rem;
+  flex: 1;
+  justify-content: center;
+  transition: all 0.15s ease;
+}
+
+.themeOption:hover {
+  color: var(--text-primary);
+  background-color: var(--surface-base);
+}
+
+.themeOptionActive {
+  background-color: var(--surface-base);
+  color: var(--text-primary);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+}
+```
+
+### Testing Checklist
+
+- [ ] Settings link in sidebar footer navigates to `/settings`
+- [ ] Settings no longer appears as an item in the sidebar nav list
+- [ ] Appearance section renders above Integrations in Settings page
+- [ ] All three theme buttons (Light, Dark, System) render with correct icons
+- [ ] Clicking each theme button immediately applies the correct theme
+- [ ] Active theme button is visually distinct from inactive buttons
+- [ ] Theme persists across page refresh (localStorage)
+- [ ] System mode follows OS preference
+- [ ] Sidebar no longer contains any theme toggle functionality
+- [ ] Dev SeedButton still renders in footer (DEV only)
+- [ ] Mobile layout: BottomNav unaffected (Settings already absent)

--- a/specs/001-consolidate-settings/research.md
+++ b/specs/001-consolidate-settings/research.md
@@ -1,0 +1,66 @@
+# Research: Consolidate Settings into Sidebar Footer
+
+**Branch**: `001-consolidate-settings` | **Date**: 2026-03-08
+
+## Current State Analysis
+
+### Sidebar Navigation (src/layout/Sidebar.tsx)
+
+- `NAV_ITEMS` array (line 9-18) contains 8 entries including `{ path: '/settings', label: 'Settings', icon: SettingsIcon }` at line 17
+- Sidebar footer (lines 137-144) contains a single `<button>` that calls `cycleTheme()` — cycles light → dark → system on click
+- Theme state comes from `useTheme()` hook (`src/features/theme/ThemeProvider.tsx`)
+- Footer CSS class is named `settingsButton` (Sidebar.module.css line 140) — misleadingly named for a theme toggle
+
+### Bottom Navigation (src/layout/BottomNav.tsx)
+
+- Already **does not include Settings** — only 6 items: Inbox, Today, Upcoming, Anytime, Someday, Logbook
+- FR-007 from the spec is already satisfied with no changes required
+
+### Settings Page (src/pages/Settings.tsx)
+
+- Single section: "Integrations" (Google Tasks connect/disconnect + list selection)
+- Uses CSS Module `Settings.module.css` with established section/card patterns
+- No theme controls present
+
+### Theme System (src/features/theme/ThemeProvider.tsx)
+
+- Provides `useTheme()` hook exposing `{ theme, setTheme }`
+- `theme` values: `'light'` | `'dark'` | `'system'`
+- Persists to `localStorage` key `"vite-ui-theme"` automatically
+- Three lucide icons already imported in Sidebar: `Sun` (light), `Moon` (dark), `Laptop` (system)
+
+## Decisions
+
+### Decision 1: Theme selector UI pattern in Settings
+
+**Decision**: Three explicit selector buttons (segmented control / button group) — not a cycle button
+**Rationale**: In Settings, discoverability matters more than brevity. Three labeled buttons (Light / Dark / System) let users see all options at a glance and select directly, unlike a cycle that requires multiple clicks and provides no visual feedback on available choices.
+**Alternatives considered**: Radio inputs (more accessible but visually heavy for 3 options), dropdown select (overkill for 3 options), cycle button like the current sidebar (poor for a settings page where all options should be visible)
+
+### Decision 2: Settings footer button element type
+
+**Decision**: Use React Router `<Link to="/settings">` wrapped in the existing footer's button-styled element (or render as a `<Link>` with button CSS)
+**Rationale**: Settings navigation is a route change, not an action. Using `<Link>` is semantically correct and provides browser-native navigation behavior (right-click to open in new tab, etc.). The existing `styles.settingsButton` CSS class remains usable for styling.
+**Alternatives considered**: `useNavigate()` hook with a `<button onClick>` — works but semantically wrong for navigation
+
+### Decision 3: CSS class rename
+
+**Decision**: Rename `settingsButton` class to `footerLink` in Sidebar.module.css
+**Rationale**: The current `settingsButton` class was named for a theme toggle button, not a settings link. Renaming aligns the class name with its new purpose and avoids future confusion.
+**Alternatives considered**: Keep `settingsButton` — works but misleading; create new class — creates dead CSS
+
+### Decision 4: Appearance section position in Settings page
+
+**Decision**: Add Appearance section **before** Integrations
+**Rationale**: Appearance is a fundamental, always-relevant preference. Integrations are optional and less commonly changed. Leading with Appearance reflects standard settings page conventions (System Preferences, iOS Settings, etc.).
+**Alternatives considered**: After Integrations — less prominent placement for a more frequently accessed setting
+
+### Decision 5: Scope of changes to Sidebar theme logic
+
+**Decision**: Remove `cycleTheme`, `ThemeIcon`, `themeLabel`, and `useTheme` import entirely from Sidebar
+**Rationale**: Sidebar no longer needs theme knowledge once the theme control moves to Settings. Removing dead code keeps the component clean.
+**Alternatives considered**: Keep the theme logic available for future use — YAGNI, dead code complicates maintenance
+
+## No NEEDS CLARIFICATION Items
+
+All decisions resolved via codebase analysis and standard UI conventions. No external research or stakeholder input required.

--- a/specs/001-consolidate-settings/spec.md
+++ b/specs/001-consolidate-settings/spec.md
@@ -1,0 +1,84 @@
+# Feature Specification: Consolidate Settings into Sidebar Footer
+
+**Feature Branch**: `001-consolidate-settings`
+**Created**: 2026-03-08
+**Status**: Draft
+**Input**: User description: "we want to move settings to the location on the UI where the button for changing light mode or dark mode is and this feature inside settings"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Access Settings from Sidebar Footer (Priority: P1)
+
+A user wants to access the application settings. Instead of clicking "Settings" in the main sidebar navigation list, they click a settings icon/button located in the sidebar footer — the same area where the theme toggle button currently lives. Clicking it navigates them to the Settings page.
+
+**Why this priority**: This is the core navigation change and the foundation for P2. Without this, the settings entry point is unchanged and the feature is not delivered.
+
+**Independent Test**: Can be fully tested by verifying that a settings icon/button appears in the sidebar footer and clicking it navigates to the Settings page. Delivers clear value: settings are accessible from the footer in a persistent, low-visual-weight location.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is on any page of the app, **When** they look at the sidebar footer, **Then** they see a settings icon/button in the footer area (where the theme toggle used to be), and "Settings" no longer appears as a separate item in the main sidebar navigation list.
+2. **Given** the user is on any page, **When** they click the settings icon/button in the sidebar footer, **Then** they are navigated to the Settings page.
+3. **Given** the user is on mobile (bottom navigation bar), **When** they look at the bottom nav, **Then** the Settings entry is removed from the bottom navigation and accessible only from the sidebar footer equivalent for mobile.
+
+---
+
+### User Story 2 - Change Theme from Within Settings (Priority: P2)
+
+A user wants to switch between light mode, dark mode, or system-default theme. They open Settings and find an "Appearance" section containing the theme toggle. They select their preferred theme and it takes effect immediately.
+
+**Why this priority**: This delivers the second half of the feature — moving the theme control into Settings. It depends on P1 (settings must be accessible) but adds meaningful discoverability of theme preferences alongside other settings.
+
+**Independent Test**: Can be fully tested by opening the Settings page, locating the Appearance section, and toggling between all three theme options (light, dark, system). Each selection must immediately change the app theme and persist after page refresh.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is on the Settings page, **When** they view the page, **Then** they see an "Appearance" section with a theme selector offering Light, Dark, and System options.
+2. **Given** the user selects "Dark Mode" in the Appearance section, **When** the selection is made, **Then** the entire app immediately switches to dark theme without requiring a page reload.
+3. **Given** the user selects a theme in Settings and then refreshes the page, **When** the page reloads, **Then** the previously selected theme is still active.
+4. **Given** the user selects "System" mode, **When** the system OS theme changes, **Then** the app follows the OS theme automatically.
+
+---
+
+### Edge Cases
+
+- What happens when a user with a bookmarked `/settings` URL opens the app after this change? The Settings page still exists at the same URL — no broken links.
+- How does the layout handle the sidebar footer when both the settings icon and potentially other footer elements are present? The footer must remain uncluttered and visually consistent.
+- What happens on mobile where there is a bottom navigation bar? The Settings entry must be removed from the bottom nav; users access Settings through a mobile-appropriate equivalent (e.g., a footer icon on mobile sidebar or through a dedicated tap target).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The main sidebar navigation list MUST NOT include a "Settings" navigation item.
+- **FR-002**: The sidebar footer MUST display a settings icon/button that navigates the user to the Settings page when tapped or clicked.
+- **FR-003**: The theme toggle control MUST be removed from the sidebar footer.
+- **FR-004**: The Settings page MUST include an "Appearance" section containing controls to switch between Light, Dark, and System theme modes.
+- **FR-005**: Selecting a theme option in the Appearance section MUST immediately apply the selected theme to the entire application without requiring a page reload.
+- **FR-006**: The selected theme preference MUST persist across page reloads and browser sessions.
+- **FR-007**: The bottom navigation bar (mobile) MUST NOT include a "Settings" navigation item.
+- **FR-008**: The Settings page MUST remain accessible at its existing URL so that any bookmarks or direct links continue to work.
+
+### Key Entities
+
+- **Theme Preference**: The user's chosen display mode (Light, Dark, or System). Persists locally on the user's device. Three possible values: light, dark, system.
+- **Settings Page**: The application screen housing all user-configurable preferences, now including an Appearance section in addition to existing Integrations content.
+- **Sidebar Footer**: The persistent bottom area of the left navigation sidebar, now serving as the primary entry point to Settings.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of users can reach the Settings page exclusively via the sidebar footer icon — the settings entry is fully removed from the main nav list and bottom nav bar.
+- **SC-002**: Users can change their theme preference in under 10 seconds from opening the Settings page for the first time.
+- **SC-003**: Theme changes apply to the full application in under 500 milliseconds of the user making a selection (visually immediate).
+- **SC-004**: The selected theme persists correctly in 100% of cases after page refresh or reopening the app in the same browser.
+- **SC-005**: The sidebar footer area remains visually uncluttered — no more than 2 icon/button elements present at any time.
+
+## Assumptions
+
+- The Settings page URL (`/settings`) does not change — this feature only moves the navigation entry point and adds the Appearance section to the page content.
+- Mobile users access Settings through the sidebar footer equivalent; the exact mobile UX pattern (e.g., hamburger menu, slide-out drawer) follows existing mobile navigation conventions already in the app.
+- The three theme modes (Light, Dark, System) remain unchanged — no new theme options are added in scope.
+- The theme preference storage mechanism (currently localStorage) remains unchanged; only the UI control location changes.
+- "System" mode means the app follows the operating system's light/dark preference automatically.

--- a/specs/001-consolidate-settings/tasks.md
+++ b/specs/001-consolidate-settings/tasks.md
@@ -1,0 +1,134 @@
+# Tasks: Consolidate Settings into Sidebar Footer
+
+**Input**: Design documents from `/specs/001-consolidate-settings/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅
+
+**Tests**: Not requested — no test tasks generated.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2)
+- Exact file paths are included in each description
+
+---
+
+## Phase 1: Setup
+
+No setup required. No new packages, routes, or infrastructure changes needed for this feature.
+
+---
+
+## Phase 2: Foundational
+
+No blocking prerequisites. User stories can start immediately and independently.
+
+---
+
+## Phase 3: User Story 1 — Access Settings from Sidebar Footer (Priority: P1) 🎯 MVP
+
+**Goal**: Remove Settings from the sidebar nav list and add a settings link to the sidebar footer, replacing the theme cycle button.
+
+**Independent Test**: Open the app, confirm Settings no longer appears in the main sidebar nav list, click the settings icon/link in the sidebar footer, and verify navigation to `/settings` page.
+
+### Implementation for User Story 1
+
+- [x] T001 [US1] Remove Settings entry from NAV_ITEMS, strip all theme logic (cycleTheme, ThemeIcon, themeLabel, useTheme import, Moon, Laptop imports), and replace the footer `<button onClick={cycleTheme}>` with `<Link to="/settings" className={styles.footerLink}><SettingsIcon size={20} /><span>Settings</span></Link>` in `src/layout/Sidebar.tsx`
+- [x] T002 [P] [US1] Rename `.settingsButton` and `.settingsButton:hover` to `.footerLink` and `.footerLink:hover` (keeping identical styles) in `src/layout/Sidebar.module.css`
+
+**Checkpoint**: User Story 1 is complete. The sidebar footer shows a "Settings" link; no Settings entry appears in the main nav list. Verify by running the dev server and manually testing navigation.
+
+---
+
+## Phase 4: User Story 2 — Change Theme from Within Settings (Priority: P2)
+
+**Goal**: Add an "Appearance" section to the Settings page with Light / Dark / System theme selector buttons, placed above the existing Integrations section.
+
+**Independent Test**: Navigate to `/settings`, confirm an Appearance section renders above Integrations with three labeled buttons (Light, Dark, System). Click each button and confirm the app theme changes immediately. Refresh the page and confirm the selected theme persists.
+
+### Implementation for User Story 2
+
+- [x] T003 [US2] Add `import { useTheme } from '../features/theme/ThemeProvider'`, `import clsx from 'clsx'`, and `import { Sun, Moon, Laptop } from 'lucide-react'` to `src/pages/Settings.tsx`; call `const { theme, setTheme } = useTheme()` inside the component; insert a new Appearance `<section>` with `.themeSelector` button group (Light/Dark/System, each with icon and label, active state via `clsx(styles.themeOption, theme === value && styles.themeOptionActive)`) immediately before the existing Integrations `<section>` in `src/pages/Settings.tsx`
+- [x] T004 [P] [US2] Add `.themeSelector`, `.themeOption`, `.themeOption:hover`, and `.themeOptionActive` CSS rules to `src/pages/Settings.module.css` — themeSelector uses flexbox with `var(--surface-overlay)` background and `var(--border-color)` border; themeOptionActive uses `var(--surface-base)` background and a subtle box-shadow; themeOption buttons share equal width via `flex: 1`
+
+**Checkpoint**: User Story 2 is complete. Navigate to `/settings` and verify the Appearance section renders with all three theme options. Verify each option applies the theme immediately and persists across page refresh.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+- [x] T005 Full smoke test: confirm sidebar footer link, removed nav entry, theme selector in Settings, theme persistence, and dev SeedButton still visible in footer (DEV mode only)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: N/A
+- **Foundational (Phase 2)**: N/A
+- **User Story 1 (Phase 3)**: No dependencies — start immediately
+- **User Story 2 (Phase 4)**: No dependencies on US1 — can start in parallel with US1
+- **Polish (Phase 5)**: Depends on US1 and US2 completion
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Independent — touches only `Sidebar.tsx` and `Sidebar.module.css`
+- **User Story 2 (P2)**: Independent — touches only `Settings.tsx` and `Settings.module.css`
+- No cross-story file conflicts; both stories can be implemented simultaneously
+
+### Within Each User Story
+
+- **US1**: T001 and T002 can run in parallel (different files — `.tsx` vs `.module.css`)
+- **US2**: T003 and T004 can run in parallel (different files — `.tsx` vs `.module.css`)
+
+### Parallel Opportunities
+
+```
+Phase 3 (US1):
+  Parallel: T001 (Sidebar.tsx) ‖ T002 (Sidebar.module.css)
+
+Phase 4 (US2):
+  Parallel: T003 (Settings.tsx) ‖ T004 (Settings.module.css)
+
+US1 and US2 phases themselves can run in parallel (no shared files):
+  Developer A: T001, T002  →  US1 complete
+  Developer B: T003, T004  →  US2 complete
+  Both: T005 (Polish)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 3: T001 + T002 (parallel)
+2. **STOP and VALIDATE**: Open dev server, confirm sidebar footer has Settings link, confirm Settings removed from nav list
+3. Merge if sufficient standalone value
+
+### Incremental Delivery
+
+1. Complete US1 (T001, T002) → Settings accessible from footer ✅
+2. Complete US2 (T003, T004) → Theme control in Settings ✅
+3. Complete Polish (T005) → Full smoke test
+
+### Parallel Team Strategy
+
+Single feature, two developers:
+- Developer A: T001, T002 → US1 done
+- Developer B: T003, T004 → US2 done
+- Together: T005 (smoke test)
+
+---
+
+## Notes
+
+- [P] tasks involve different files and have no shared dependencies — safe to run in parallel
+- All 4 implementation tasks (T001–T004) are UI-only changes; no backend or data layer touched
+- `clsx` is already a dependency in the project (used in Sidebar.tsx)
+- `SettingsIcon` import already exists in `Sidebar.tsx` (line 2) — no new imports needed for Step 2
+- `Sun`, `Moon`, `Laptop` are already imported in `Sidebar.tsx` — after removal of theme logic these move to `Settings.tsx`
+- `useTheme` hook is already battle-tested; no changes to ThemeProvider needed

--- a/src/layout/Sidebar.module.css
+++ b/src/layout/Sidebar.module.css
@@ -137,7 +137,7 @@
   margin-top: auto;
 }
 
-.settingsButton {
+.footerLink {
   display: flex;
   align-items: center;
   gap: 0.75rem;
@@ -147,7 +147,7 @@
   transition: color 0.2s ease;
 }
 
-.settingsButton:hover {
+.footerLink:hover {
   color: var(--text-primary);
 }
 

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -1,7 +1,6 @@
 import { Link, useLocation } from 'react-router-dom';
-import { Inbox, Sun, Calendar, Layers, Archive, Moon, Laptop, PlusCircle, FolderPlus, MoreHorizontal, CheckSquare, Sparkles, Settings as SettingsIcon } from 'lucide-react';
+import { Inbox, Sun, Calendar, Layers, Archive, PlusCircle, FolderPlus, MoreHorizontal, CheckSquare, Sparkles, Settings as SettingsIcon } from 'lucide-react';
 import clsx from 'clsx';
-import { useTheme } from '../features/theme/ThemeProvider';
 import styles from './Sidebar.module.css';
 import { SeedButton } from '../dev/SeedButton';
 import { Project, PROJECT_COLORS } from '../shared/types/task';
@@ -14,7 +13,6 @@ const NAV_ITEMS = [
   { path: '/someday', label: 'Someday', icon: Archive, color: 'accent-lavender' },
   { path: '/logbook', label: 'Logbook', icon: CheckSquare, color: 'text-secondary' },
   { path: '/briefing', label: 'AI Briefing', icon: Sparkles, color: 'accent-lavender' },
-  { path: '/settings', label: 'Settings', icon: SettingsIcon, color: 'text-secondary' },
 ];
 
 interface SidebarProps {
@@ -28,16 +26,6 @@ interface SidebarProps {
 
 export function Sidebar({ onNewTask, projects = [], onNewProject, onEditProject, activeProjectId, setActiveProjectId }: SidebarProps) {
   const location = useLocation();
-  const { theme, setTheme } = useTheme();
-
-  const cycleTheme = () => {
-    if (theme === 'light') setTheme('dark');
-    else if (theme === 'dark') setTheme('system');
-    else setTheme('light');
-  };
-
-  const ThemeIcon = theme === 'light' ? Sun : theme === 'dark' ? Moon : Laptop;
-  const themeLabel = theme === 'light' ? 'Light' : theme === 'dark' ? 'Dark' : 'System';
 
   const getProjectHex = (color: string) => {
     return PROJECT_COLORS.find(c => c.name === color)?.hex || '#86868b';
@@ -135,11 +123,11 @@ export function Sidebar({ onNewTask, projects = [], onNewProject, onEditProject,
       </div>
 
       <div className={styles.footer}>
-        <button className={styles.settingsButton} onClick={cycleTheme} title="Toggle Theme">
-          <ThemeIcon size={20} />
-          <span>{themeLabel} Mode</span>
-        </button>
-        
+        <Link to="/settings" className={styles.footerLink}>
+          <SettingsIcon size={20} />
+          <span>Settings</span>
+        </Link>
+
         {import.meta.env.DEV && <SeedButton />}
       </div>
     </aside>

--- a/src/pages/Settings.module.css
+++ b/src/pages/Settings.module.css
@@ -47,6 +47,40 @@
   font-size: 0.875rem;
 }
 
+.themeSelector {
+  display: flex;
+  gap: var(--spacing-1);
+  background-color: var(--surface-overlay);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-1);
+}
+
+.themeOption {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-4);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-weight: 500;
+  font-size: 0.875rem;
+  flex: 1;
+  transition: all 0.15s ease;
+}
+
+.themeOption:hover {
+  color: var(--text-primary);
+  background-color: var(--surface-base);
+}
+
+.themeOptionActive {
+  background-color: var(--surface-base);
+  color: var(--text-primary);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+}
+
 .integrationCard {
   background-color: var(--surface-overlay);
   border: 1px solid var(--border-color);

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,6 +1,8 @@
-import { Settings as SettingsIcon } from 'lucide-react';
+import { Settings as SettingsIcon, Sun, Moon, Laptop } from 'lucide-react';
+import clsx from 'clsx';
 import styles from './Settings.module.css';
 import { useAuth } from '../lib/auth/AuthContext';
+import { useTheme } from '../features/theme/ThemeProvider';
 import { useState, useEffect } from 'react';
 import { doc, getDoc, updateDoc } from 'firebase/firestore';
 import { db, functions } from '../lib/firebase';
@@ -11,8 +13,15 @@ interface GoogleTaskList {
   title: string;
 }
 
+const THEME_OPTIONS = [
+  { value: 'light' as const, label: 'Light', Icon: Sun },
+  { value: 'dark' as const, label: 'Dark', Icon: Moon },
+  { value: 'system' as const, label: 'System', Icon: Laptop },
+];
+
 export function Settings() {
   const { user, connectGoogleTasks, disconnectGoogleTasks } = useAuth();
+  const { theme, setTheme } = useTheme();
   const [isConnecting, setIsConnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isConnected, setIsConnected] = useState(false);
@@ -127,6 +136,22 @@ export function Settings() {
       </header>
 
       <div className={styles.settingsContent}>
+        <section className={styles.settingsSection}>
+          <h2>Appearance</h2>
+          <div className={styles.themeSelector}>
+            {THEME_OPTIONS.map(({ value, label, Icon }) => (
+              <button
+                key={value}
+                className={clsx(styles.themeOption, theme === value && styles.themeOptionActive)}
+                onClick={() => setTheme(value)}
+              >
+                <Icon size={18} />
+                <span>{label}</span>
+              </button>
+            ))}
+          </div>
+        </section>
+
         <section className={styles.settingsSection}>
           <h2>Integrations</h2>
           

--- a/tests/settings-nav.spec.ts
+++ b/tests/settings-nav.spec.ts
@@ -1,0 +1,47 @@
+/// <reference types="node" />
+import { test, expect } from './auth';
+
+test.describe('Settings Navigation & Theme', () => {
+  test('Settings is not in the sidebar nav list', async ({ loggedInPage: page }) => {
+    await page.goto('/');
+    await expect(page.getByTestId('nav-item-settings')).not.toBeVisible();
+  });
+
+  test('Settings link in sidebar footer navigates to /settings', async ({ loggedInPage: page }) => {
+    await page.goto('/');
+    const settingsLink = page.locator('aside a[href="/settings"]');
+    await expect(settingsLink).toBeVisible({ timeout: 5000 });
+    await settingsLink.click();
+    await expect(page).toHaveURL('/settings');
+  });
+
+  test('Settings page has Appearance section above Integrations', async ({ loggedInPage: page }) => {
+    await page.goto('/settings');
+    const sections = page.locator('h2');
+    const firstSection = sections.first();
+    await expect(firstSection).toHaveText('Appearance');
+  });
+
+  test('Appearance section shows Light, Dark, System buttons', async ({ loggedInPage: page }) => {
+    await page.goto('/settings');
+    await expect(page.getByRole('button', { name: /light/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /dark/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /system/i })).toBeVisible();
+  });
+
+  test('Selecting Dark theme persists after page reload', async ({ loggedInPage: page }) => {
+    await page.goto('/settings');
+    await page.getByRole('button', { name: /dark/i }).click();
+    await expect(page.locator('html')).toHaveAttribute('class', /dark/);
+    await page.reload();
+    await expect(page.locator('html')).toHaveAttribute('class', /dark/);
+  });
+
+  test('Selecting Light theme persists after page reload', async ({ loggedInPage: page }) => {
+    await page.goto('/settings');
+    await page.getByRole('button', { name: /light/i }).click();
+    await expect(page.locator('html')).not.toHaveAttribute('class', /dark/);
+    await page.reload();
+    await expect(page.locator('html')).not.toHaveAttribute('class', /dark/);
+  });
+});


### PR DESCRIPTION
…ngs page

- Remove Settings from sidebar nav list; add Settings link to sidebar footer
- Replace theme cycle button in footer with a Link navigating to /settings
- Add Appearance section to Settings page with Light/Dark/System selector
- Add e2e tests for settings navigation and theme persistence
- Add specs for 001-consolidate-settings feature