### PR TITLE
feat: implement drag-and-drop priority ordering for projects, columns…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,8 @@ Auto-generated from all feature plans. Last updated: 2026-03-09
 - Firebase Firestore — new sub-collection `users/{uid}/kanbanStatuses`; extended `Task` document with `kanbanStatusId` field (001-project-kanban)
 - TypeScript 5.9 / React 19.2 + Firebase 12.9 (Firestore real-time `onSnapshot`), @dnd-kit/core + @dnd-kit/sortable (drag-and-drop), React Router 7.13, Lucide React (001-kanban-done-sync)
 - Firestore — `users/{uid}/tasks` (Task documents with `status`, `completedAt`, `kanbanStatusId`), `users/{uid}/kanbanStatuses` (KanbanStatus documents with `isFinal` flag) (001-kanban-done-sync)
+- TypeScript 5.9 / React 19.2 + @dnd-kit/core, @dnd-kit/sortable, @dnd-kit/utilities (all installed); Firebase 12.9 Firestore; React Router 7.13; Lucide React (001-project-drag-ordering)
+- Firestore — `users/{uid}/projects`, `users/{uid}/kanbanStatuses`, `users/{uid}/tasks` (001-project-drag-ordering)
 
 - TypeScript / Node.js + React 19, Vite, Firebase, Framer Motion, Lucide React (025-new-task-alignment)
 - TypeScript 5.x + React 18 + React Router v6 (Link/useLocation), lucide-react (icons), CSS Modules (001-consolidate-settings)
@@ -30,9 +32,9 @@ npm test; npm run lint
 TypeScript / Node.js: Follow standard conventions
 
 ## Recent Changes
+- 001-project-drag-ordering: Added TypeScript 5.9 / React 19.2 + @dnd-kit/core, @dnd-kit/sortable, @dnd-kit/utilities (all installed); Firebase 12.9 Firestore; React Router 7.13; Lucide React
 - 001-kanban-done-sync: Added TypeScript 5.9 / React 19.2 + Firebase 12.9 (Firestore real-time `onSnapshot`), @dnd-kit/core + @dnd-kit/sortable (drag-and-drop), React Router 7.13, Lucide React
 - 001-project-kanban: Added TypeScript 5.9 + React 19.2 + @dnd-kit/core, @dnd-kit/sortable, @dnd-kit/utilities (new); Framer Motion 12.34 (existing, for animations); Firebase 12.9 (existing); React Router 7.13 (existing); Lucide React (existing)
-- 026-settings-page-alignment: Added TypeScript / React 19 + Lucide React, clsx, Firebase (auth/firestore/functions)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/specs/001-project-drag-ordering/checklists/requirements.md
+++ b/specs/001-project-drag-ordering/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Project & Kanban Drag-and-Drop Priority Ordering
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-07
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- One assumption worth flagging before planning: task ordering within columns (FR-008/FR-009) may already be partially implemented by the existing `002-task-drag-drop` branch — confirm overlap during planning.

--- a/specs/001-project-drag-ordering/contracts/hooks.md
+++ b/specs/001-project-drag-ordering/contracts/hooks.md
@@ -1,0 +1,153 @@
+# Hook Contracts: Project & Kanban Drag-and-Drop Priority Ordering
+
+**Branch**: `001-project-drag-ordering` | **Date**: 2026-04-07
+
+These contracts describe the public interface of hooks that are added or modified by this feature. Existing unchanged hooks are omitted.
+
+---
+
+## `useProjects` (modified)
+
+**File**: `frontend/src/features/projects/hooks/useProjects.ts`
+
+### Changes from current
+
+| Change | Before | After |
+|---|---|---|
+| Firestore query sort | `orderBy('createdAt', 'asc')` | `orderBy('order', 'asc')` |
+| New method | — | `reorderProjects(orderedIds: string[]): Promise<void>` |
+
+### New method contract
+
+```typescript
+/**
+ * Persists a new project display order to Firestore.
+ * Writes a batch update assigning each project a new `order` integer
+ * equal to its index in `orderedIds`.
+ *
+ * @param orderedIds - Array of project IDs in the desired display order,
+ *                     from highest priority (index 0) to lowest.
+ * @returns Promise that resolves when all Firestore writes complete.
+ * @throws Firestore write errors propagate to the caller.
+ */
+reorderProjects(orderedIds: string[]): Promise<void>
+```
+
+**Behaviour**:
+- Performs a single Firestore `WriteBatch` with one `update({ order: index })` per project.
+- Does not mutate the local `projects` state; the `onSnapshot` listener will reflect the new order after the batch commits.
+- Caller is responsible for optimistic local state if instant visual feedback is needed.
+
+---
+
+## `useKanbanBoard` (modified)
+
+**File**: `frontend/src/features/kanban/hooks/useKanbanBoard.ts`
+
+### Changes from current
+
+| Change | Before | After |
+|---|---|---|
+| New method | — | `reorderColumns(orderedIds: string[]): Promise<void>` |
+| New method | — | `reorderTasksInColumn(columnId: string, orderedTaskIds: string[]): Promise<void>` |
+
+### New method contracts
+
+```typescript
+/**
+ * Delegates to reorderStatuses() from useKanbanStatuses.
+ * Convenience wrapper so KanbanBoard only imports one hook.
+ *
+ * @param orderedIds - Column (KanbanStatus) IDs in desired left-to-right order.
+ */
+reorderColumns(orderedIds: string[]): Promise<void>
+
+/**
+ * Reorders tasks within a single column.
+ * Calls reorderTasks() with tasks sorted to match orderedTaskIds.
+ *
+ * @param columnId    - The KanbanStatus ID whose tasks are being reordered.
+ * @param orderedTaskIds - Task IDs in the desired top-to-bottom order within the column.
+ */
+reorderTasksInColumn(columnId: string, orderedTaskIds: string[]): Promise<void>
+```
+
+---
+
+## `KanbanBoard` component (modified)
+
+**File**: `frontend/src/features/kanban/KanbanBoard.tsx`
+
+### DragEnd routing logic (new)
+
+```typescript
+// In onDragEnd handler — branch on drag type
+if (active.data.current?.type === 'column') {
+  // Column reorder: call reorderColumns(newColumnOrder)
+} else {
+  // Task drag (existing logic)
+  if (sourceColumnId === destColumnId) {
+    // Same-column reorder: call reorderTasksInColumn(...)
+  } else {
+    // Cross-column move: call moveTask(...) [unchanged]
+  }
+}
+```
+
+### Data attributes on draggable elements
+
+| Element | `data.current.type` | `data.current.id` |
+|---|---|---|
+| Column header drag handle | `'column'` | KanbanStatus ID |
+| Task card | `'task'` | Task ID |
+
+---
+
+## `DraggableProjectList` component (new)
+
+**File**: `frontend/src/features/projects/DraggableProjectList.tsx`
+
+```typescript
+interface DraggableProjectListProps {
+  /** Ordered list of projects to display */
+  projects: Project[];
+  /** Currently active project ID (highlighted in sidebar) */
+  activeProjectId: string | null;
+  /** Called when user clicks a project (navigate to it) */
+  onSelectProject: (projectId: string) => void;
+  /** Called when user requests project edit */
+  onEditProject: (project: Project) => void;
+  /** Called when drag-drop completes with new ordered IDs */
+  onReorder: (orderedIds: string[]) => void;
+}
+```
+
+**Behaviour**:
+- Uses `@dnd-kit/sortable`: `SortableContext` + `verticalListSortingStrategy`.
+- Each project item uses `useSortable` with `id = project.id`.
+- Drag handle is a dedicated icon element (not the whole row) to preserve click-to-navigate.
+- Calls `onReorder` once on `DragEndEvent` (not on every drag-over).
+- Shows `DragOverlay` of the dragged project row while in flight.
+- Preserves all existing project row UI (color dot, name, edit button).
+
+---
+
+## `Sidebar` component (modified)
+
+**File**: `frontend/src/layout/Sidebar.tsx`
+
+### Changes from current
+
+| Change | Before | After |
+|---|---|---|
+| Project list rendering | `projects.map(...)` with static `<li>` items | `<DraggableProjectList>` component |
+| New prop | — | `onReorderProjects: (orderedIds: string[]) => void` |
+
+### Updated props
+
+```typescript
+interface SidebarProps {
+  // ... existing props unchanged ...
+  onReorderProjects: (orderedIds: string[]) => void; // new
+}
+```

--- a/specs/001-project-drag-ordering/data-model.md
+++ b/specs/001-project-drag-ordering/data-model.md
@@ -1,0 +1,125 @@
+# Data Model: Project & Kanban Drag-and-Drop Priority Ordering
+
+**Branch**: `001-project-drag-ordering` | **Date**: 2026-04-07
+
+## Overview
+
+All three key entities (`Project`, `KanbanStatus`, `Task`) already have an `order` field in the data model. No Firestore schema migrations are required. The changes are limited to:
+1. Fixing the project query to sort by `order` instead of `createdAt`.
+2. Adding a `reorderProjects()` operation (write path only).
+
+---
+
+## Entities
+
+### Project
+
+**Firestore path**: `users/{uid}/projects/{projectId}`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `id` | string | yes | Document ID |
+| `title` | string | yes | Display name |
+| `color` | string | yes | One of the PROJECT_COLORS enum values |
+| `order` | number | yes | Zero-based integer; lower = higher priority in left menu |
+| `createdAt` | string (ISO) | yes | Used as tiebreaker for initial ordering |
+
+**Changes**: No schema change. Query changed from `orderBy('createdAt')` → `orderBy('order')`.
+
+**Ordering rules**:
+- On create: `order = currentProjects.length` (already implemented)
+- On reorder: all affected projects receive a new integer `order` value (0-based, contiguous)
+- On delete: remaining projects are NOT re-indexed (gaps are acceptable; relative order is preserved)
+
+---
+
+### KanbanStatus (Kanban Column)
+
+**Firestore path**: `users/{uid}/kanbanStatuses/{statusId}`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `id` | string | yes | Document ID |
+| `label` | string | yes | Column header text |
+| `order` | number | yes | Zero-based integer; lower = leftmost on board |
+| `isFinal` | boolean | yes | If true, moving a task here marks it complete |
+| `createdAt` | string (ISO) | yes | Creation timestamp |
+
+**Changes**: No schema change. The `reorderStatuses()` hook and query (`orderBy('order')`) already exist and work correctly.
+
+---
+
+### Task
+
+**Firestore path**: `users/{uid}/tasks/{taskId}`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `id` | string | yes | Document ID |
+| `title` | string | yes | Task title |
+| `status` | string | yes | `'todo' \| 'completed' \| 'canceled' \| 'someday'` |
+| `projectId` | string | no | References a Project document ID |
+| `kanbanStatusId` | string | no | References a KanbanStatus document ID |
+| `order` | number | no | Position within its kanban column; lower = higher in column |
+| `createdAt` | string (ISO) | yes | Creation timestamp |
+| `completedAt` | string (ISO) | no | Set when task moves to a final column |
+| `updatedAt` | string (ISO) | no | Last modification timestamp |
+
+**Changes**: No schema change. `reorderTasks()` already exists and writes correct `order` values. The kanban board UI needs to call it on intra-column card reorder.
+
+**Key invariant**: `projectId` is the authoritative link between a task and its project. Reordering (of projects, columns, or tasks) MUST NOT modify `projectId`. This is guaranteed by the existing hook implementations.
+
+---
+
+## State Transitions
+
+### Project Reorder
+
+```
+User drags project in Sidebar
+  → optimistic UI update (local state reorder)
+  → reorderProjects(newOrderedIds[]) called
+    → Firestore batch: update each project doc with new order integer
+  → onSnapshot fires → UI confirms persisted order
+```
+
+### Column Reorder (on board)
+
+```
+User drags column header on KanbanBoard
+  → DragEndEvent fires with type='column'
+  → arrayMove(columns, fromIndex, toIndex) → newOrder
+  → reorderStatuses(newOrder.map(s => s.id)) called
+    → Firestore batch: update each status doc with new order integer
+  → useKanbanStatuses onSnapshot fires → board re-renders in new order
+```
+
+### Task Reorder (within column)
+
+```
+User drags card within same column
+  → DragEndEvent fires with type='task', same source & dest column
+  → arrayMove(columnTasks, fromIndex, toIndex) → reorderedTasks
+  → reorderTasks(reorderedTasks) called
+    → Firestore batch: update each task doc with new order integer
+  → useTasks onSnapshot fires → column re-renders in new order
+```
+
+### Task Move (cross-column)
+
+```
+User drags card to different column (existing behaviour, unchanged)
+  → DragEndEvent fires with type='task', different dest column
+  → moveTask(taskId, toStatusId) called
+    → Updates task.kanbanStatusId + status + completedAt if isFinal
+```
+
+---
+
+## Firestore Security Rules
+
+No changes required. The existing rules allow all field updates on projects, tasks, and kanbanStatuses as long as the core validation passes:
+
+- `isValidProject()` checks `title` (string, non-empty) and `color` (string or null) — `order` updates pass through.
+- `isValidTask()` checks `title`, `status` enum, and `projectId` — `order` updates pass through.
+- `kanbanStatuses` has blanket read/write for owner — no validation function, all updates allowed.

--- a/specs/001-project-drag-ordering/plan.md
+++ b/specs/001-project-drag-ordering/plan.md
@@ -1,0 +1,109 @@
+# Implementation Plan: Project & Kanban Drag-and-Drop Priority Ordering
+
+**Branch**: `001-project-drag-ordering` | **Date**: 2026-04-07 | **Spec**: [spec.md](spec.md)  
+**Input**: Feature specification from `/specs/001-project-drag-ordering/spec.md`
+
+## Summary
+
+Users need drag-and-drop reordering for projects in the left sidebar and for kanban columns on the board, with task ordering within columns as a follow-on. All three Firestore entities (`Project`, `KanbanStatus`, `Task`) already have `order` fields, and reorder hook methods already exist for kanban statuses and tasks. The implementation adds project reordering to `useProjects`, wires a sortable project list into `Sidebar`, and extends `KanbanBoard` to handle column and intra-column card drags alongside the existing cross-column task drag — all using the already-installed `@dnd-kit` library.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.9 / React 19.2  
+**Primary Dependencies**: @dnd-kit/core, @dnd-kit/sortable, @dnd-kit/utilities (all installed); Firebase 12.9 Firestore; React Router 7.13; Lucide React  
+**Storage**: Firestore — `users/{uid}/projects`, `users/{uid}/kanbanStatuses`, `users/{uid}/tasks`  
+**Testing**: npm test (existing test suite)  
+**Target Platform**: Web (desktop-first, same as rest of app)  
+**Project Type**: Web application (React SPA + Firebase backend)  
+**Performance Goals**: Reorder UI feedback < 100ms; Firestore batch writes < 1s on normal network  
+**Constraints**: No new npm dependencies; no Firestore schema changes; must not break existing kanban task drag  
+**Scale/Scope**: Single-user data (each user's order is independent); typical project count: 1–30
+
+## Constitution Check
+
+The project constitution file is a blank template (no ratified principles). No gates apply. ✅
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-project-drag-ordering/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── hooks.md         # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks — not created here)
+```
+
+### Source Code (modified files)
+
+```text
+frontend/src/
+├── features/
+│   ├── projects/
+│   │   ├── hooks/
+│   │   │   └── useProjects.ts            # Add reorderProjects(), fix query sort
+│   │   └── DraggableProjectList.tsx      # New: sortable project list component
+│   └── kanban/
+│       ├── KanbanBoard.tsx               # Extend onDragEnd for column + intra-column drags
+│       ├── KanbanColumn.tsx              # Add useSortable + drag handle for column header
+│       ├── KanbanCard.tsx                # Switch useDraggable → useSortable
+│       └── hooks/
+│           └── useKanbanBoard.ts         # Add reorderColumns(), reorderTasksInColumn()
+└── layout/
+    ├── Sidebar.tsx                       # Replace project map with DraggableProjectList
+    └── MainLayout.tsx                    # Pass reorderProjects handler to Sidebar
+```
+
+## Complexity Tracking
+
+No constitution violations.
+
+---
+
+## Phase 0: Research
+
+**Status**: Complete — see [research.md](research.md)
+
+All NEEDS CLARIFICATION items resolved. No new npm dependencies required. No Firestore schema changes required.
+
+---
+
+## Phase 1: Design & Contracts
+
+**Status**: Complete
+
+### Artifacts
+
+- **Data model**: [data-model.md](data-model.md) — documents existing `order` fields, state transitions, Firestore rules analysis
+- **Hook & component contracts**: [contracts/hooks.md](contracts/hooks.md) — defines `reorderProjects()`, `reorderColumns()`, `reorderTasksInColumn()`, `DraggableProjectList` props, `Sidebar` prop addition
+- **Quickstart**: [quickstart.md](quickstart.md)
+
+### Key Design Decisions
+
+1. **One DndContext per surface**: `KanbanBoard` uses a single `DndContext` that handles both column drags and task drags, branching in `onDragEnd` on `active.data.current.type`. Nested contexts cause pointer event conflicts.
+
+2. **Type tagging for drag items**: Column drag handles set `data: { type: 'column', id }`. Task cards set `data: { type: 'task', id }`. This is the @dnd-kit-recommended pattern for mixed drag targets.
+
+3. **Sidebar uses @dnd-kit**: Consistent with the kanban column reordering pattern. Projects get a vertical sortable list with a dedicated drag handle (grabber icon) to avoid conflict with the click-to-navigate behaviour.
+
+4. **No optimistic local state**: The `onSnapshot` real-time listener refreshes state within ~100–200ms of a Firestore write. Optimistic updates are not needed for this latency target.
+
+5. **reorderProjects() uses WriteBatch**: Assigns each project `order = index` in a single atomic batch write. Same pattern as `reorderStatuses()`.
+
+6. **Project query fixed**: `orderBy('createdAt', 'asc')` → `orderBy('order', 'asc')`. Existing projects without contiguous `order` values will display in correct relative order; gaps are harmless.
+
+### Implementation Slices (ordered by FR priority)
+
+| Slice | User Story | Files Changed |
+|---|---|---|
+| A: Project reorder — hook | US-1 | `useProjects.ts` |
+| B: Project reorder — UI | US-1 | `DraggableProjectList.tsx`, `Sidebar.tsx`, `MainLayout.tsx` |
+| C: Column reorder on board — hook | US-2 | `useKanbanBoard.ts` |
+| D: Column reorder on board — UI | US-2 | `KanbanBoard.tsx`, `KanbanColumn.tsx` |
+| E: Task reorder within column — UI | US-3/US-4 | `KanbanBoard.tsx`, `KanbanCard.tsx` |
+
+Slices A and B can be developed and tested independently of C–E. Slice C must precede D. Slice E can be done after D (shares the same `DndContext` extension).

--- a/specs/001-project-drag-ordering/quickstart.md
+++ b/specs/001-project-drag-ordering/quickstart.md
@@ -1,0 +1,92 @@
+# Quickstart: Project & Kanban Drag-and-Drop Priority Ordering
+
+**Branch**: `001-project-drag-ordering` | **Date**: 2026-04-07
+
+## Prerequisites
+
+All dependencies are already installed. No `npm install` needed.
+
+```bash
+# Verify @dnd-kit packages are present
+grep "@dnd-kit" frontend/package.json
+```
+
+## Local Development
+
+```bash
+# Start the frontend dev server
+cd frontend
+npm run dev
+```
+
+The app is a Firebase-connected React SPA. Firestore changes are real-time via `onSnapshot`.
+
+## Testing the Feature
+
+### Slice A+B: Project reordering in Sidebar
+
+1. Open the app and ensure at least 2 projects exist (use "New Project" or the seed button in dev mode).
+2. Hover over a project in the left sidebar — a grab handle icon should appear.
+3. Drag the project up or down; a placeholder should show the drop target.
+4. Release — the project should appear in the new position.
+5. Refresh the page — the order should persist.
+6. Click a project after reordering — only that project's tasks appear on the board.
+
+### Slice C+D: Column reordering on the Kanban board
+
+1. Open a project's Kanban board with at least 2 columns.
+2. Hover over a column header — a grab handle icon should appear.
+3. Drag the column left or right; adjacent columns shift to show the drop target.
+4. Release — the column appears in the new position with its tasks intact.
+5. Refresh or navigate away and back — column order persists.
+
+### Slice E: Task reordering within a column
+
+1. On a Kanban board, hover over a task card — a drag handle should appear.
+2. Drag the card up or down within the same column.
+3. Release — the card appears in the new position.
+4. Refresh — the order persists.
+5. Drag the card to a different column — existing status-change behaviour still works.
+
+## Key Files to Understand
+
+| File | Purpose |
+|---|---|
+| `frontend/src/features/projects/hooks/useProjects.ts` | Firestore CRUD + new `reorderProjects()` |
+| `frontend/src/features/projects/DraggableProjectList.tsx` | New sortable project list component |
+| `frontend/src/layout/Sidebar.tsx` | Left navigation panel |
+| `frontend/src/features/kanban/KanbanBoard.tsx` | Main board — DndContext orchestration |
+| `frontend/src/features/kanban/KanbanColumn.tsx` | Individual column — add `useSortable` |
+| `frontend/src/features/kanban/KanbanCard.tsx` | Task card — switch to `useSortable` |
+| `frontend/src/features/kanban/hooks/useKanbanBoard.ts` | Board state + new reorder delegates |
+| `frontend/src/features/kanban/KanbanStatusManager.tsx` | Reference implementation of column sortable |
+| `frontend/src/shared/types/task.ts` | Type definitions for Project, KanbanStatus, Task |
+
+## Reference: Existing Sortable Pattern (KanbanStatusManager)
+
+`KanbanStatusManager.tsx` is the best reference for the drag-and-drop pattern to replicate:
+
+```typescript
+// Pattern to follow for DraggableProjectList and KanbanBoard column sorting
+<DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+  <SortableContext items={ids} strategy={verticalListSortingStrategy}>
+    {items.map(item => <SortableItem key={item.id} id={item.id} {...item} />)}
+  </SortableContext>
+</DndContext>
+
+// In onDragEnd:
+function handleDragEnd({ active, over }) {
+  if (!over || active.id === over.id) return;
+  const oldIndex = ids.indexOf(active.id);
+  const newIndex = ids.indexOf(over.id);
+  const newOrder = arrayMove(ids, oldIndex, newIndex);
+  reorderStatuses(newOrder); // or reorderProjects(newOrder)
+}
+```
+
+## Firestore Console Verification
+
+To verify persistence during development, check the Firestore console:
+- `users/{uid}/projects` — each document should have an `order` field (integer)
+- `users/{uid}/kanbanStatuses` — each document should have `order` updated on column reorder
+- `users/{uid}/tasks` — each document should have `order` updated on task reorder

--- a/specs/001-project-drag-ordering/research.md
+++ b/specs/001-project-drag-ordering/research.md
@@ -1,0 +1,95 @@
+# Research: Project & Kanban Drag-and-Drop Priority Ordering
+
+**Branch**: `001-project-drag-ordering` | **Date**: 2026-04-07
+
+## Decisions & Rationale
+
+---
+
+### Decision 1: Use @dnd-kit/sortable for project reordering in Sidebar
+
+**Decision**: Extend `@dnd-kit/sortable` (already installed) to the project list in `Sidebar.tsx`, following the exact same pattern already used in `KanbanStatusManager.tsx`.
+
+**Rationale**: Consistency. The app already has two drag-and-drop libraries coexisting (@dnd-kit for kanban, Framer Motion for task lists). Adding @dnd-kit to the Sidebar keeps it aligned with the kanban column reorder pattern (which is most similar in structure: a vertical list of named items). No new dependencies needed.
+
+**Alternatives considered**:
+- Framer Motion `Reorder` (already used in `ReorderableTaskList.tsx`): rejected because it's used only for task lists within page views, not for sidebar navigation items.
+- react-beautiful-dnd: rejected — not installed, would add a new dependency.
+
+---
+
+### Decision 2: Kanban column drag-and-drop on the board itself (not just in settings)
+
+**Decision**: Add column reordering directly to `KanbanBoard.tsx` by nesting a `SortableContext` (items = column IDs) inside the existing `DndContext`, using a drag handle on column headers. Distinguish column drags from task drags via the `active.data.current.type` convention (@dnd-kit data attribute).
+
+**Rationale**: The spec (FR-003) requires column reordering on the board. `KanbanStatusManager.tsx` already has this for the settings view, but the board is a separate surface. The existing `DndContext` in `KanbanBoard.tsx` handles task drags; we extend it to handle both types by branching in `onDragEnd`.
+
+**Alternatives considered**:
+- Point users to the existing KanbanStatusManager (settings) for column reordering: rejected — the spec explicitly calls for board-level drag-and-drop.
+- Separate `DndContext` wrappers for columns vs tasks: rejected — nested DndContexts cause pointer event conflicts in @dnd-kit; the recommended pattern is one context with type tagging.
+
+**Implementation pattern (from @dnd-kit docs)**:
+```
+DndContext (onDragEnd branches on active.data.current.type)
+  ├── SortableContext (column IDs, horizontalListSortingStrategy)
+  │   └── KanbanColumn (useSortable, drag handle on header)
+  └── Each KanbanColumn contains:
+      └── SortableContext (task IDs within column, verticalListSortingStrategy)  [future FR-008]
+          └── KanbanCard (useSortable / useDraggable)
+```
+
+---
+
+### Decision 3: Task reordering within columns (FR-007/FR-008)
+
+**Decision**: Migrate `KanbanCard` from `useDraggable` to `useSortable` within each column's `SortableContext`. The existing `reorderTasks()` hook method in `useTasks.ts` is already implemented — only the UI wiring is missing.
+
+**Rationale**: `reorderTasks()` already writes correct Firestore batch updates. Task drag-between-columns (status change) via `moveTask()` also already exists in `useKanbanBoard.ts`. The gap is purely in the UI: cards need `useSortable` instead of `useDraggable`, and `onDragEnd` must handle same-column reordering vs cross-column moves.
+
+**Alternatives considered**:
+- Keep Framer Motion `Reorder` for task ordering within columns: rejected — Framer Motion's `Reorder` cannot be composed inside @dnd-kit's `DndContext` without losing drop coordination. Unifying on @dnd-kit avoids library conflicts.
+
+---
+
+### Decision 4: Project `order` field initialisation
+
+**Decision**: On `addProject()`, assign `order = projects.length` (already done in `useProjects.ts`). Change the Firestore query from `orderBy('createdAt', 'asc')` to `orderBy('order', 'asc')`.
+
+**Rationale**: The `ProjectDocument` type already has `order: number`. The only gap is that the query ignores it. Existing projects without a proper `order` value will need a one-time migration (assign order = index based on createdAt sort) handled in `reorderProjects()` on first drag.
+
+**Alternatives considered**:
+- Keep createdAt ordering and only change on drag: rejected — the order would reset on refresh unless persisted via the `order` field.
+- Firestore compound index on (order, createdAt): not needed; single `order` field index is sufficient.
+
+---
+
+### Decision 5: Existing overlap with `002-task-drag-drop` branch
+
+**Finding**: The `002-task-drag-drop` branch added `reorderTasks()` to `useTasks.ts` and `ReorderableTaskList.tsx`. Both are already present in the current `001-project-drag-ordering` branch (merged or cherry-picked). The Framer Motion approach is used for task list views (Inbox, Today, etc.) and is not the same surface as kanban task ordering.
+
+**Decision**: The kanban board will use @dnd-kit for card ordering within columns (separate from the Framer Motion task list used in non-kanban views). The same `reorderTasks()` hook serves both.
+
+---
+
+## What Already Exists (No New Work Needed)
+
+| Capability | Location | Status |
+|---|---|---|
+| `@dnd-kit/core`, `/sortable`, `/utilities` installed | package.json | ✅ ready |
+| `order` field on Project | `firestore.ts` → `ProjectDocument` | ✅ exists |
+| `order` field on KanbanStatus | `task.ts` → `KanbanStatus` | ✅ exists |
+| `order` field on Task | `task.ts` → `Task` | ✅ optional, exists |
+| `reorderStatuses(orderedIds[])` | `useKanbanStatuses.ts` | ✅ implemented |
+| `reorderTasks(reorderedTasks[])` | `useTasks.ts` | ✅ implemented |
+| Column drag-and-drop (settings view) | `KanbanStatusManager.tsx` | ✅ implemented |
+| Task drag between columns | `KanbanBoard.tsx` + `useKanbanBoard.ts` | ✅ implemented |
+| Firestore rules for all collections | `firestore.rules` | ✅ allow `order` updates |
+
+## What Needs to Be Built
+
+| Capability | File | Gap |
+|---|---|---|
+| `reorderProjects(orderedIds[])` | `useProjects.ts` | Missing method + query fix |
+| Draggable project list | `Sidebar.tsx` or new `DraggableProjectList.tsx` | Missing UI |
+| Column drag on board | `KanbanBoard.tsx` + `KanbanColumn.tsx` | Missing sortable wiring |
+| Card sortable within column | `KanbanCard.tsx` + `KanbanBoard.tsx` | Missing sortable wiring |

--- a/specs/001-project-drag-ordering/spec.md
+++ b/specs/001-project-drag-ordering/spec.md
@@ -1,0 +1,122 @@
+# Feature Specification: Project & Kanban Drag-and-Drop Priority Ordering
+
+**Feature Branch**: `001-project-drag-ordering`  
+**Created**: 2026-04-07  
+**Status**: Draft  
+**Input**: User description: "we should be able to drag and drop order on the kanban board and also on the main menu panel on the left, but the tasks also get re-organized so when the customer clicks on the project it keeps displaying the tasks associated to the project. this will help us to look at projects based on priorities"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Reorder Projects in the Left Navigation Menu (Priority: P1)
+
+As a user, I want to drag projects up and down in the left-hand menu panel so that my most important projects appear at the top and the order reflects my current priorities.
+
+**Why this priority**: The left menu is the primary navigation surface. Establishing a persistent priority order there is the foundational capability — everything else (kanban board column order, task display order) builds on the same ordering data.
+
+**Independent Test**: Can be fully tested by opening the app, dragging a project to a new position in the left menu, refreshing the page, and verifying the new order persists.
+
+**Acceptance Scenarios**:
+
+1. **Given** the left menu lists multiple projects, **When** the user drags a project card to a new position, **Then** the project moves to that position and all other projects shift accordingly.
+2. **Given** the user has reordered projects, **When** the user refreshes the page or reopens the app, **Then** the custom order is restored exactly as left.
+3. **Given** a new project is created, **When** it appears in the left menu, **Then** it is added at the bottom of the list (lowest priority by default).
+
+---
+
+### User Story 2 - Reorder Kanban Columns by Dragging (Priority: P2)
+
+As a user, I want to drag and drop the columns on the kanban board to rearrange their order so that I can reflect the workflow priority or process stages that matter most right now.
+
+**Why this priority**: The kanban board is the primary task-management view. Allowing column reordering gives users control over their workflow stages without affecting core navigation, making it a valuable but self-contained enhancement.
+
+**Independent Test**: Can be fully tested by opening a project's kanban board, dragging one column to a new position, navigating away, returning to the board, and confirming the column order persisted.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project kanban board is open with multiple columns, **When** the user drags a column header to a new horizontal position, **Then** the column drops into that position and all other columns shift to accommodate.
+2. **Given** the user has reordered columns, **When** the user navigates away and returns to the kanban board, **Then** the column order is restored to what was last set.
+3. **Given** column order has been changed, **When** the user views the tasks within each column, **Then** each task remains associated with its correct column and is not lost or reassigned.
+
+---
+
+### User Story 3 - Tasks Remain Associated with Their Project After Reordering (Priority: P2)
+
+As a user, I want that after reordering projects or columns, clicking any project in the left menu still shows only that project's tasks — correctly organized — so that reordering never causes data loss or cross-project task mixing.
+
+**Why this priority**: This is a correctness guarantee. Without it, drag-and-drop reordering could appear to work but actually corrupt the user's view of their data.
+
+**Independent Test**: Can be fully tested by reordering projects, clicking each project in turn, and verifying its task list contains only the tasks originally assigned to it.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has reordered projects in the left menu, **When** the user clicks any project, **Then** only tasks belonging to that project are displayed on the kanban board.
+2. **Given** the user has reordered kanban columns within a project, **When** the user clicks a different project and returns, **Then** the column order is still correct and no tasks have moved to a different column.
+3. **Given** multiple projects each have tasks in overlapping column names (e.g., both have a "To Do" column), **When** the user reorders either project's columns, **Then** only that project's column order changes; the other project is unaffected.
+
+---
+
+### User Story 4 - Drag-and-Drop Tasks Within and Between Kanban Columns (Priority: P3)
+
+As a user, I want to drag tasks between columns and within a column to change their status and relative priority so that the board always reflects the current state of work.
+
+**Why this priority**: Task reordering within the board extends the ordering concept to the task level, completing the priority-management story. It is lower priority because project-level and column-level ordering (P1/P2) delivers the headline value first.
+
+**Independent Test**: Can be fully tested by dragging a task from one column to another and verifying its status updates accordingly, then refreshing to confirm persistence.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task is in one column, **When** the user drags it to a different column, **Then** the task moves to the new column and its status updates to match that column's status.
+2. **Given** multiple tasks in a single column, **When** the user drags one task above or below another, **Then** the vertical order within the column is updated and persists after page reload.
+3. **Given** a task is dragged to the final/done column, **When** the move is confirmed, **Then** the task is marked complete following existing completion rules.
+
+---
+
+### Edge Cases
+
+- What happens when the user drags a project and drops it back in the same position? The order should remain unchanged with no unnecessary saves.
+- What happens when two users (or two browser tabs) reorder the same project list simultaneously? The last save wins; no silent data corruption.
+- What happens when there is only one project or one column? Drag-and-drop should still activate but produce no visible change.
+- How does the system handle a very long list of projects that overflows the left menu? The drag target should remain reachable (scrolling while dragging is supported or the list scrolls automatically).
+- What happens if the network is unavailable when the user drops a project/column? The reorder should be attempted and the user notified if it could not be saved; the UI should not silently revert.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Users MUST be able to drag and drop projects in the left navigation menu to change their display order.
+- **FR-002**: The project order established in the left menu MUST persist across page reloads, browser sessions, and devices for the same user account.
+- **FR-003**: Users MUST be able to drag and drop kanban board columns to change their horizontal order within a project.
+- **FR-004**: The kanban column order MUST persist per project, independently for each project.
+- **FR-005**: Reordering projects or columns MUST NOT alter task-to-project or task-to-column associations.
+- **FR-006**: Clicking a project in the left menu MUST always display only the tasks belonging to that project, regardless of any reordering that has occurred.
+- **FR-007**: Users MUST be able to drag tasks between kanban columns to update their status.
+- **FR-008**: Users MUST be able to drag tasks vertically within a column to set their priority order within that column.
+- **FR-009**: Task order within columns MUST persist per project per column.
+- **FR-010**: A newly created project MUST be placed at the bottom (lowest priority) of the left menu order by default.
+- **FR-011**: A newly created kanban column MUST be appended at the rightmost position by default.
+- **FR-012**: The system MUST provide clear visual affordance (drag handle or cursor change) indicating which elements are draggable.
+- **FR-013**: The system MUST show a visual placeholder or highlight indicating the drop target position while the user is dragging.
+
+### Key Entities
+
+- **Project Order**: A user-specific ordered list of project identifiers representing the user's chosen priority sequence for projects in the left menu.
+- **Column Order**: A project-specific ordered list of kanban column (status) identifiers representing the display sequence of columns on the board.
+- **Task Order**: A column-specific ordered list of task identifiers representing the display sequence of tasks within a kanban column.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user can reorder a project in the left menu in under 5 seconds (drag, drop, confirmed).
+- **SC-002**: Project order, column order, and task order each persist correctly after page reload 100% of the time under normal network conditions.
+- **SC-003**: Clicking any project immediately after reordering displays only that project's tasks — zero cross-project task leakage.
+- **SC-004**: All reordering interactions (project, column, task) complete with visible confirmation within 1 second under normal network conditions.
+- **SC-005**: Users report that locating their highest-priority project requires fewer steps after using drag-to-reorder ordering compared to the previous fixed order.
+
+## Assumptions
+
+- Each user has their own independent project order; reordering by one user does not affect any other user's view.
+- The existing kanban column drag-and-drop infrastructure (@dnd-kit) is already present in the codebase and will be extended, not replaced.
+- "Tasks associated to the project" means the task-to-project relationship is stored in each task's data record and is not inferred from ordering alone.
+- The left menu panel already lists projects; this feature adds drag-to-reorder without redesigning the panel's visual layout.
+- Offline/conflict resolution defaults to last-write-wins, consistent with existing Firestore usage in the app.

--- a/specs/001-project-drag-ordering/tasks.md
+++ b/specs/001-project-drag-ordering/tasks.md
@@ -1,0 +1,192 @@
+# Tasks: Project & Kanban Drag-and-Drop Priority Ordering
+
+**Input**: Design documents from `/specs/001-project-drag-ordering/`  
+**Branch**: `001-project-drag-ordering`  
+**Tests**: Not requested — no test tasks generated.
+
+**Organization**: Tasks grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on each other)
+- **[Story]**: Which user story this task belongs to (US1–US4)
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Verify the existing codebase is understood and nothing needs to be installed before feature work begins.
+
+- [x] T001 Read `frontend/src/features/projects/hooks/useProjects.ts` and `frontend/src/layout/Sidebar.tsx` to confirm current project list rendering and hook shape before making changes
+- [x] T002 Read `frontend/src/features/kanban/KanbanBoard.tsx`, `frontend/src/features/kanban/KanbanColumn.tsx`, and `frontend/src/features/kanban/KanbanCard.tsx` to confirm current drag-and-drop wiring before extending it
+- [x] T003 [P] Read `frontend/src/features/kanban/KanbanStatusManager.tsx` to capture the exact `@dnd-kit/sortable` pattern to replicate for projects and columns
+- [x] T004 [P] Read `frontend/src/shared/types/task.ts` and `frontend/src/lib/types/firestore.ts` to confirm `order` field presence on `Project`, `KanbanStatus`, and `Task` types
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Fix the project query sort order so projects display by `order` rather than `createdAt`. This must ship before any drag UI, otherwise reorders won't persist visually on refresh.
+
+**⚠️ CRITICAL**: US1 UI work (Phase 3) depends on this being complete first.
+
+- [x] T005 In `frontend/src/features/projects/hooks/useProjects.ts`, change the Firestore query from `orderBy('createdAt', 'asc')` to `orderBy('order', 'asc')` so projects are fetched in their persisted priority order
+- [x] T006 In `frontend/src/features/projects/hooks/useProjects.ts`, add `reorderProjects(orderedIds: string[]): Promise<void>` method that writes a single Firestore `WriteBatch` assigning each project `order = index` (0-based), following the same pattern as the existing `reorderStatuses()` in `useKanbanStatuses.ts`
+
+**Checkpoint**: `useProjects` now returns projects in `order` sequence and can persist reorders to Firestore. Verify by temporarily logging the `projects` array order before proceeding.
+
+---
+
+## Phase 3: User Story 1 — Reorder Projects in the Left Navigation Menu (Priority: P1) 🎯 MVP
+
+**Goal**: Users can drag projects up and down in the left sidebar; order persists across refreshes.
+
+**Independent Test**: Open app → drag a project to a new position in the left sidebar → refresh → confirm order persists → click a project → confirm only that project's tasks appear.
+
+### Implementation
+
+- [x] T007 [US1] Create `frontend/src/features/projects/DraggableProjectList.tsx` — a new component that wraps the project list in `DndContext` + `SortableContext` (verticalListSortingStrategy) from `@dnd-kit/sortable`, renders each project as a `useSortable` item with a `GripVertical` drag handle icon (Lucide React), preserves existing color-dot / name / edit-button UI, and calls an `onReorder(orderedIds: string[])` prop on drag end (only when position actually changed). Use `KanbanStatusManager.tsx` as the reference implementation.
+- [x] T008 [US1] Add `DragOverlay` to `DraggableProjectList.tsx` showing a ghost of the dragged project row while in flight, so the user has visual confirmation of the item being moved
+- [x] T009 [US1] Update `frontend/src/layout/Sidebar.tsx` to import and render `DraggableProjectList` in place of the current `projects.map(...)` list, and add a new `onReorderProjects: (orderedIds: string[]) => void` prop to the `SidebarProps` interface
+- [x] T010 [US1] Update `frontend/src/layout/MainLayout.tsx` to call `reorderProjects` from `useProjects` and pass it as `onReorderProjects` to `<Sidebar>` so the wire-up from drag gesture → Firestore batch write is complete
+
+**Checkpoint**: US1 fully functional. Drag a project in the sidebar, release, refresh — order persists. Click each project — only its own tasks shown. No regression in existing project click-to-navigate or edit flow.
+
+---
+
+## Phase 4: User Story 2 — Reorder Kanban Columns by Dragging (Priority: P2)
+
+**Goal**: Users can drag column headers on the kanban board to reorder columns; order persists across navigation.
+
+**Independent Test**: Open a project kanban board → drag a column header to a new position → navigate away → return → column order matches what was set → tasks are still in their correct columns.
+
+### Implementation
+
+- [x] T011 [US2] In `frontend/src/features/kanban/hooks/useKanbanBoard.ts`, add `reorderColumns(orderedIds: string[]): Promise<void>` that delegates to `reorderStatuses(orderedIds)` from the existing `useKanbanStatuses` hook, so `KanbanBoard` only needs to import one hook for all board operations
+- [x] T012 [US2] Update `frontend/src/features/kanban/KanbanColumn.tsx` to accept drag-handle props from `useSortable` — add a `GripVertical` drag handle element in the column header area, wire the `listeners`, `attributes`, and `setNodeRef` from `useSortable` to the column container, and accept a `dragHandleProps` or equivalent pattern so the rest of the column (task drop target) is unchanged
+- [x] T013 [US2] Update `frontend/src/features/kanban/KanbanBoard.tsx` to wrap the column list in a `SortableContext` (items = column IDs, `horizontalListSortingStrategy`) nested inside the existing `DndContext`, tag each column drag handle with `data: { type: 'column', id }`, and extend `onDragEnd` to branch on `active.data.current?.type === 'column'` — when true, compute the new column order with `arrayMove` and call `reorderColumns(newOrder.map(c => c.id))`; when false, fall through to existing task drag logic
+- [x] T014 [US2] Add a `DragOverlay` branch in `frontend/src/features/kanban/KanbanBoard.tsx` for column drags — render a compact column-header ghost (label + task count) when a column is being dragged, in addition to the existing card ghost for task drags
+
+**Checkpoint**: US2 fully functional. Drag a column header left or right on the board, release, navigate away and back — column order persists. Tasks remain in their correct columns. No regression in task drag-between-columns.
+
+---
+
+## Phase 5: User Story 3 — Task-to-Project Association Integrity After Reordering (Priority: P2)
+
+**Goal**: Verify and harden the guarantee that reordering projects or columns never alters `projectId` or `kanbanStatusId` on any task, so each project's kanban board always shows exactly its own tasks.
+
+**Independent Test**: Reorder projects in sidebar → click each project in turn → verify its board shows only tasks with `projectId` matching that project → reorder columns → verify no tasks changed columns.
+
+**Note**: This is largely a correctness guarantee delivered by the hook implementations in T006 and T011. The tasks here add a defensive check and ensure the UI filtering is bulletproof.
+
+### Implementation
+
+- [x] T015 [P] [US3] Audit `frontend/src/features/projects/DraggableProjectList.tsx` (T007) and `frontend/src/features/projects/hooks/useProjects.ts` (T006) to confirm that `reorderProjects` only writes the `order` field and never touches `projectId`, `kanbanStatusId`, or task documents — add a JSDoc comment on `reorderProjects` explicitly stating this invariant
+- [x] T016 [P] [US3] Audit `frontend/src/features/kanban/hooks/useKanbanBoard.ts` (T011) to confirm `reorderColumns` only writes the `order` field on `kanbanStatuses` documents and never modifies task documents — add a JSDoc comment stating this invariant
+- [x] T017 [US3] In `frontend/src/features/kanban/hooks/useKanbanBoard.ts`, verify that the `tasksByColumn` memo (which groups tasks per column) uses `task.kanbanStatusId` as the group key and is unaffected by column `order` changes — if it currently derives grouping from position rather than ID, fix it to use `kanbanStatusId`
+- [x] T018 [US3] Verify that clicking a project in `frontend/src/layout/Sidebar.tsx` filters the kanban board by `projectId` (not by project list position) — confirm in `frontend/src/pages/Kanban.tsx` or wherever the active project filter is applied, and document the filter location with a comment if not already obvious
+
+**Checkpoint**: US3 validated. After any reordering, each project shows only its own tasks. No cross-project leakage. Audit comments in place as guardrails for future maintainers.
+
+---
+
+## Phase 6: User Story 4 — Drag Tasks Within and Between Kanban Columns (Priority: P3)
+
+**Goal**: Cards can be dragged vertically within a column to set priority order, and horizontally between columns to change status. Both persist.
+
+**Independent Test**: Drag a card within a column → refresh → card position persists. Drag a card to another column → status updates → refresh → card stays in new column.
+
+**Note**: Cross-column task drag already works (existing `moveTask()` call in `KanbanBoard`). The gap is intra-column reordering (cards currently use `useDraggable`, not `useSortable`) and the `reorderTasksInColumn` wire-up.
+
+### Implementation
+
+- [x] T019 [US4] In `frontend/src/features/kanban/hooks/useKanbanBoard.ts`, add `reorderTasksInColumn(columnId: string, orderedTaskIds: string[]): Promise<void>` that filters `tasks` to the given column, builds the reordered `Task[]` array in `orderedTaskIds` order, and calls the existing `reorderTasks(reorderedTasks)` from `useTasks`
+- [x] T020 [US4] Update `frontend/src/features/kanban/KanbanCard.tsx` to switch from `useDraggable` to `useSortable` from `@dnd-kit/sortable`, tagging the drag item with `data: { type: 'task', id, columnId }` — keep the existing visual styling and dragging-state CSS class; the external API (props) should remain unchanged
+- [x] T021 [US4] Update `frontend/src/features/kanban/KanbanColumn.tsx` to wrap its task list in a `SortableContext` (items = task IDs in that column, `verticalListSortingStrategy`) alongside the existing `useDroppable` drop target — the column must work as both a sortable container (for intra-column reorder) and a droppable zone (for cross-column moves)
+- [x] T022 [US4] Extend `onDragEnd` in `frontend/src/features/kanban/KanbanBoard.tsx` to handle the same-column task reorder case: when `active.data.current?.type === 'task'` and source column ID equals destination column ID, call `reorderTasksInColumn(columnId, newTaskOrder)` using `arrayMove`; when source ≠ destination, use the existing `moveTask()` path (unchanged)
+
+**Checkpoint**: US4 fully functional. Intra-column drag reorders cards and persists on refresh. Cross-column drag still updates task status. Tasks dragged to the final/done column are still marked complete per existing logic.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Visual polish, edge-case handling, and overall UX consistency across all four stories.
+
+- [x] T023 [P] Add CSS cursor style `cursor: grab` on all drag handles (project list, column headers, task cards) in the relevant component files so the affordance is consistent — `cursor: grabbing` while actively dragging
+- [x] T024 [P] Handle the edge case in `frontend/src/features/projects/DraggableProjectList.tsx` where a user drops a project back in its original position: guard in `onDragEnd` so `onReorder` is NOT called and no Firestore write is issued (check `active.id !== over?.id` before proceeding)
+- [x] T025 [P] Handle the same no-op drop edge case in `frontend/src/features/kanban/KanbanBoard.tsx` for both column reorders and task reorders: skip the reorder call when `active.id === over?.id`
+- [x] T026 TypeScript build passes (npx tsc --noEmit) with zero errors — all acceptance criteria verified structurally
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately.
+- **Foundational (Phase 2)**: Depends on Phase 1 reads. **Blocks US1 UI work (Phase 3).**
+- **US1 — Phase 3**: Depends on Phase 2 (needs `reorderProjects` hook). Blocks nothing else.
+- **US2 — Phase 4**: Depends on Phase 1 reads only (hook + UI both touch kanban files). Can run in parallel with Phase 3 after Phase 1.
+- **US3 — Phase 5**: Depends on Phase 3 (T015 audits T007/T006) and Phase 4 (T016 audits T011). Run after both.
+- **US4 — Phase 6**: Depends on Phase 4 (T020–T022 extend the column sortable context added in T021). Run after Phase 4.
+- **Polish (Phase 7)**: Depends on all story phases complete.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends on Foundational (Phase 2). No other story dependency.
+- **US2 (P2)**: Depends on Phase 1 reads only. Can start in parallel with US1.
+- **US3 (P2)**: Depends on US1 + US2 (audits their implementations). Run after both.
+- **US4 (P3)**: Depends on US2 (reuses column `SortableContext` added there). Run after US2.
+
+### Parallel Opportunities
+
+- T003 and T004 (Phase 1 reads) can run in parallel.
+- T005 and T006 (Phase 2) are sequential (T006 adds a new method; T005 changes the query — both in the same file, so write them in one pass).
+- T007 and T011 (new hook method + new component) can run in parallel since they touch different files.
+- T012 and T019 can run in parallel (different files: `KanbanColumn.tsx` vs hook).
+- T015 and T016 (US3 audits) can run in parallel (different files).
+- T023, T024, T025 (Polish) can all run in parallel (different files/concerns).
+
+---
+
+## Parallel Example: US1 + US2 (after Phase 2 complete)
+
+```
+Parallel stream A (US1):
+  T007 → T008 → T009 → T010
+
+Parallel stream B (US2):
+  T011 → T012 → T013 → T014
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Read key files (T001–T004)
+2. Complete Phase 2: Fix query + add `reorderProjects` (T005–T006)
+3. Complete Phase 3: Build `DraggableProjectList` + wire sidebar (T007–T010)
+4. **STOP and VALIDATE**: Drag projects in sidebar, refresh, confirm order persists
+5. Ship / demo: Users can already prioritize projects
+
+### Incremental Delivery
+
+1. Phase 1 + 2 → foundation ready
+2. Phase 3 → **MVP: project ordering in sidebar**
+3. Phase 4 → add kanban column ordering on board
+4. Phase 5 → association integrity verification (low-risk, mostly auditing)
+5. Phase 6 → add intra-column task ordering
+6. Phase 7 → polish and edge cases
+
+---
+
+## Notes
+
+- [P] tasks touch different files and have no inter-dependencies — safe to parallelize.
+- [Story] label maps each task to its user story for traceability back to `spec.md`.
+- Reference implementation for all sortable patterns: `frontend/src/features/kanban/KanbanStatusManager.tsx`.
+- `reorderProjects`, `reorderStatuses`, `reorderTasks` all use Firestore `WriteBatch` — same pattern, same atomicity guarantee.
+- Do not modify `projectId` or `kanbanStatusId` in any reorder operation — these are the authoritative task-to-project and task-to-column links.

--- a/src/features/kanban/KanbanBoard.module.css
+++ b/src/features/kanban/KanbanBoard.module.css
@@ -119,3 +119,35 @@
   font-size: 0.875rem;
   margin: 0;
 }
+
+/* Column drag ghost (shown in DragOverlay when dragging a column) */
+.columnGhost {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: 6px var(--spacing-sm);
+  background: var(--bg-paper);
+  border: 1.5px solid var(--accent-sapphire);
+  border-radius: 8px;
+  box-shadow: var(--shadow-lg);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--accent-sapphire);
+  white-space: nowrap;
+  opacity: 0.96;
+  transform: rotate(1.5deg);
+}
+
+.columnGhostLabel {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.columnGhostCount {
+  background: var(--bg-app);
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  padding: 1px 7px;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}

--- a/src/features/kanban/KanbanBoard.tsx
+++ b/src/features/kanban/KanbanBoard.tsx
@@ -1,8 +1,18 @@
 import { useState } from 'react';
-import { DndContext, DragEndEvent, DragOverlay, DragStartEvent, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
+import {
+  DndContext,
+  DragEndEvent,
+  DragOverlay,
+  DragStartEvent,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import { SortableContext, arrayMove, horizontalListSortingStrategy } from '@dnd-kit/sortable';
 import { LayoutDashboard } from 'lucide-react';
 import clsx from 'clsx';
-import { Task, Project, PROJECT_COLORS } from '../../shared/types/task';
+import { Task, Project, KanbanStatus, PROJECT_COLORS } from '../../shared/types/task';
 import { KanbanColumn } from './KanbanColumn';
 import { KanbanCard } from './KanbanCard';
 import { useKanbanBoard } from './hooks/useKanbanBoard';
@@ -17,12 +27,28 @@ function getProjectHex(color: string) {
   return PROJECT_COLORS.find((c) => c.name === color)?.hex || '#86868b';
 }
 
+/** Ghost rendered in DragOverlay when a column header is being dragged */
+function ColumnGhost({ status, taskCount }: { status: KanbanStatus; taskCount: number }) {
+  return (
+    <div className={styles.columnGhost}>
+      <span className={styles.columnGhostLabel}>{status.label}</span>
+      <span className={styles.columnGhostCount}>{taskCount}</span>
+    </div>
+  );
+}
+
 export function KanbanBoard({ projects, onEditTask }: KanbanBoardProps) {
+  // Project selection is by document ID (not list position), so drag-reordering
+  // projects in the sidebar never affects which tasks are shown here.
+  // useKanbanBoard filters tasks via where('projectId', '==', selectedProjectId).
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(
     projects.length > 0 ? projects[0].id : null
   );
-  const { statuses, tasksByColumn, loading, moveTask } = useKanbanBoard(selectedProjectId);
-  const [activeTaskId, setActiveTaskId] = useState<string | null>(null);
+  const { statuses, tasksByColumn, loading, moveTask, reorderColumns, reorderTasksInColumn } =
+    useKanbanBoard(selectedProjectId);
+
+  // Track what's being dragged: { type: 'column' | 'task', id: string }
+  const [activeDrag, setActiveDrag] = useState<{ type: string; id: string } | null>(null);
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -31,27 +57,67 @@ export function KanbanBoard({ projects, onEditTask }: KanbanBoardProps) {
   );
 
   const allTasks = Object.values(tasksByColumn).flat();
-  const activeTask = activeTaskId ? allTasks.find((t) => t.id === activeTaskId) ?? null : null;
+  const activeTask =
+    activeDrag?.type === 'task'
+      ? (allTasks.find((t) => t.id === activeDrag.id) ?? null)
+      : null;
+  const activeColumn =
+    activeDrag?.type === 'column'
+      ? (statuses.find((s) => s.id === activeDrag.id) ?? null)
+      : null;
 
   const handleDragStart = (event: DragStartEvent) => {
-    setActiveTaskId(event.active.id as string);
+    const type = (event.active.data.current?.type as string) ?? 'task';
+    setActiveDrag({ type, id: event.active.id as string });
   };
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
-    setActiveTaskId(null);
+    setActiveDrag(null);
 
-    if (!over) return;
+    if (!over || active.id === over.id) return;
+
+    const type = active.data.current?.type as string;
+
+    if (type === 'column') {
+      // Column reorder
+      const oldIndex = statuses.findIndex((s) => s.id === active.id);
+      const newIndex = statuses.findIndex((s) => s.id === over.id);
+      if (oldIndex !== -1 && newIndex !== -1 && oldIndex !== newIndex) {
+        const newOrder = arrayMove(statuses, oldIndex, newIndex);
+        reorderColumns(newOrder.map((s) => s.id));
+      }
+      return;
+    }
+
+    // Task drag
     const taskId = active.id as string;
-    const toStatusId = over.id as string;
+    const sourceColumnId = active.data.current?.columnId as string | undefined;
+    // over could be a task (has columnId) or a column drop zone (its id is a status id)
+    const overIsColumn = statuses.some((s) => s.id === over.id);
+    const destColumnId = overIsColumn
+      ? (over.id as string)
+      : (over.data.current?.columnId as string | undefined);
 
-    // Find source column — no-op if same column
-    const sourceColumnId = statuses.find((s) =>
-      tasksByColumn[s.id]?.some((t) => t.id === taskId)
-    )?.id;
+    if (!destColumnId) return;
 
-    if (sourceColumnId === toStatusId) return;
-    moveTask(taskId, toStatusId);
+    if (sourceColumnId && sourceColumnId === destColumnId) {
+      // Same-column reorder
+      const columnTasks = tasksByColumn[sourceColumnId] ?? [];
+      const oldIdx = columnTasks.findIndex((t) => t.id === taskId);
+      const newIdx = columnTasks.findIndex((t) => t.id === over.id);
+      if (oldIdx !== -1 && newIdx !== -1 && oldIdx !== newIdx) {
+        const newOrder = arrayMove(
+          columnTasks.map((t) => t.id),
+          oldIdx,
+          newIdx
+        );
+        reorderTasksInColumn(sourceColumnId, newOrder);
+      }
+    } else {
+      // Cross-column move
+      moveTask(taskId, destColumnId);
+    }
   };
 
   if (projects.length === 0) {
@@ -104,23 +170,34 @@ export function KanbanBoard({ projects, onEditTask }: KanbanBoardProps) {
       ) : (
         <DndContext
           sensors={sensors}
+          collisionDetection={closestCenter}
           onDragStart={handleDragStart}
           onDragEnd={handleDragEnd}
         >
-          <div className={styles.columns}>
-            {statuses.map((status) => (
-              <KanbanColumn
-                key={status.id}
-                status={status}
-                tasks={tasksByColumn[status.id] ?? []}
-                projects={projects}
-                onEditRequest={onEditTask}
-              />
-            ))}
-          </div>
+          <SortableContext
+            items={statuses.map((s) => s.id)}
+            strategy={horizontalListSortingStrategy}
+          >
+            <div className={styles.columns}>
+              {statuses.map((status) => (
+                <KanbanColumn
+                  key={status.id}
+                  status={status}
+                  tasks={tasksByColumn[status.id] ?? []}
+                  projects={projects}
+                  onEditRequest={onEditTask}
+                />
+              ))}
+            </div>
+          </SortableContext>
 
           <DragOverlay dropAnimation={null}>
-            {activeTask ? (
+            {activeColumn ? (
+              <ColumnGhost
+                status={activeColumn}
+                taskCount={(tasksByColumn[activeColumn.id] ?? []).length}
+              />
+            ) : activeTask ? (
               <KanbanCard
                 task={activeTask}
                 projects={projects}

--- a/src/features/kanban/KanbanCard.tsx
+++ b/src/features/kanban/KanbanCard.tsx
@@ -1,4 +1,5 @@
-import { useDraggable } from '@dnd-kit/core';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import { Edit2 } from 'lucide-react';
 import clsx from 'clsx';
 import { Task, PROJECT_COLORS, Project } from '../../shared/types/task';
@@ -9,9 +10,10 @@ interface KanbanCardProps {
   projects: Project[];
   onEditRequest: (task: Task) => void;
   isOverlay?: boolean;
+  columnId?: string;
 }
 
-function CardContent({ task, projects, onEditRequest }: Omit<KanbanCardProps, 'isOverlay'>) {
+function CardContent({ task, projects, onEditRequest }: Omit<KanbanCardProps, 'isOverlay' | 'columnId'>) {
   const project = task.projectId
     ? projects.find((p) => p.id === task.projectId)
     : null;
@@ -68,15 +70,22 @@ function CardContent({ task, projects, onEditRequest }: Omit<KanbanCardProps, 'i
   );
 }
 
-export function KanbanCard({ task, projects, onEditRequest, isOverlay }: KanbanCardProps) {
-  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+export function KanbanCard({ task, projects, onEditRequest, isOverlay, columnId }: KanbanCardProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: task.id,
     disabled: isOverlay,
+    data: { type: 'task', id: task.id, columnId },
   });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
 
   return (
     <div
       ref={setNodeRef}
+      style={style}
       {...(!isOverlay ? listeners : {})}
       {...(!isOverlay ? attributes : {})}
       className={clsx(

--- a/src/features/kanban/KanbanColumn.module.css
+++ b/src/features/kanban/KanbanColumn.module.css
@@ -6,6 +6,31 @@
   flex: 1;
 }
 
+.columnDragging {
+  opacity: 0.35;
+}
+
+.dragHandle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-tertiary);
+  cursor: grab;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  flex-shrink: 0;
+  touch-action: none;
+  margin-right: var(--spacing-xs);
+}
+
+.column:hover .dragHandle {
+  opacity: 1;
+}
+
+.dragHandle:active {
+  cursor: grabbing;
+}
+
 .header {
   display: flex;
   align-items: center;

--- a/src/features/kanban/KanbanColumn.tsx
+++ b/src/features/kanban/KanbanColumn.tsx
@@ -1,5 +1,8 @@
 import { useDroppable } from '@dnd-kit/core';
-import { CheckCircle } from 'lucide-react';
+import { useSortable } from '@dnd-kit/sortable';
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { CheckCircle, GripVertical } from 'lucide-react';
 import clsx from 'clsx';
 import { Task, KanbanStatus, Project } from '../../shared/types/task';
 import { KanbanCard } from './KanbanCard';
@@ -13,11 +16,44 @@ interface KanbanColumnProps {
 }
 
 export function KanbanColumn({ status, tasks, projects, onEditRequest }: KanbanColumnProps) {
-  const { setNodeRef, isOver } = useDroppable({ id: status.id });
+  // useSortable for the column itself (column reordering)
+  const {
+    attributes,
+    listeners,
+    setNodeRef: setSortableRef,
+    transform,
+    transition,
+    isDragging: isColumnDragging,
+  } = useSortable({
+    id: status.id,
+    data: { type: 'column', id: status.id },
+  });
+
+  // useDroppable for the inner task drop zone (task cross-column drops)
+  const { setNodeRef: setDropRef, isOver } = useDroppable({ id: status.id });
+
+  const columnStyle = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  const taskIds = tasks.map((t) => t.id);
 
   return (
-    <div className={styles.column}>
+    <div
+      ref={setSortableRef}
+      style={columnStyle}
+      className={clsx(styles.column, isColumnDragging && styles.columnDragging)}
+    >
       <div className={styles.header}>
+        <span
+          className={styles.dragHandle}
+          {...listeners}
+          {...attributes}
+          title="Drag to reorder column"
+        >
+          <GripVertical size={14} />
+        </span>
         <span className={styles.label}>{status.label}</span>
         <div className={styles.headerRight}>
           {status.isFinal && (
@@ -30,25 +66,28 @@ export function KanbanColumn({ status, tasks, projects, onEditRequest }: KanbanC
       </div>
 
       <div
-        ref={setNodeRef}
+        ref={setDropRef}
         className={clsx(styles.dropZone, isOver && styles.dropOver)}
       >
-        {tasks.length > 0 ? (
-          <div className={styles.cardList}>
-            {tasks.map((task) => (
-              <KanbanCard
-                key={task.id}
-                task={task}
-                projects={projects}
-                onEditRequest={onEditRequest}
-              />
-            ))}
-          </div>
-        ) : (
-          <div className={styles.emptyColumn}>
-            <span>Drop tasks here</span>
-          </div>
-        )}
+        <SortableContext items={taskIds} strategy={verticalListSortingStrategy}>
+          {tasks.length > 0 ? (
+            <div className={styles.cardList}>
+              {tasks.map((task) => (
+                <KanbanCard
+                  key={task.id}
+                  task={task}
+                  projects={projects}
+                  onEditRequest={onEditRequest}
+                  columnId={status.id}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className={styles.emptyColumn}>
+              <span>Drop tasks here</span>
+            </div>
+          )}
+        </SortableContext>
       </div>
     </div>
   );

--- a/src/features/kanban/hooks/useKanbanBoard.ts
+++ b/src/features/kanban/hooks/useKanbanBoard.ts
@@ -117,7 +117,7 @@ export function useKanbanBoard(projectId: string | null) {
         if (destinationStatus.isFinal) {
           await updateDoc(taskRef, {
             status: 'completed',
-            completedAt: serverTimestamp(),
+            completedAt: new Date().toISOString(),
             kanbanStatusId: toStatusId,
             updatedAt: serverTimestamp(),
           });

--- a/src/features/kanban/hooks/useKanbanBoard.ts
+++ b/src/features/kanban/hooks/useKanbanBoard.ts
@@ -6,6 +6,7 @@ import {
   onSnapshot,
   doc,
   updateDoc,
+  writeBatch,
   serverTimestamp,
 } from 'firebase/firestore';
 import { db } from '../../../lib/firebase';
@@ -15,7 +16,7 @@ import { useKanbanStatuses } from './useKanbanStatuses';
 
 export function useKanbanBoard(projectId: string | null) {
   const { user } = useAuth();
-  const { statuses, loading: statusesLoading } = useKanbanStatuses();
+  const { statuses, loading: statusesLoading, reorderStatuses } = useKanbanStatuses();
   const [tasks, setTasks] = useState<Task[]>([]);
   const [tasksLoading, setTasksLoading] = useState(true);
 
@@ -76,6 +77,16 @@ export function useKanbanBoard(projectId: string | null) {
       result[colId].push(task);
     });
 
+    // Sort tasks within each column by their persisted `order` field
+    statuses.forEach((s) => {
+      result[s.id].sort((a, b) => {
+        const aOrder = a.order ?? Infinity;
+        const bOrder = b.order ?? Infinity;
+        if (aOrder !== bOrder) return aOrder - bOrder;
+        return a.createdAt < b.createdAt ? -1 : 1;
+      });
+    });
+
     return result;
   }, [tasks, statuses]);
 
@@ -124,10 +135,45 @@ export function useKanbanBoard(projectId: string | null) {
     [user, statuses]
   );
 
+  /**
+   * Reorders kanban columns (statuses) by delegating to reorderStatuses.
+   * IMPORTANT: Only writes the `order` field on kanbanStatus documents —
+   * never modifies task documents. Task-to-column associations (kanbanStatusId)
+   * are preserved entirely.
+   */
+  const reorderColumns = useCallback(
+    (orderedIds: string[]) => reorderStatuses(orderedIds),
+    [reorderStatuses]
+  );
+
+  /**
+   * Reorders tasks within a single column by their new top-to-bottom order.
+   * Writes a WriteBatch assigning each task `order = index` (0-based).
+   * Only writes the `order` field — never modifies projectId or kanbanStatusId.
+   */
+  const reorderTasksInColumn = useCallback(
+    async (columnId: string, orderedTaskIds: string[]) => {
+      if (!user) return;
+      const columnTasks = tasksByColumn[columnId] ?? [];
+      const batch = writeBatch(db);
+      orderedTaskIds.forEach((id, index) => {
+        const task = columnTasks.find((t) => t.id === id);
+        if (task && !task.isGoogleTask) {
+          const ref = doc(db, 'users', user.uid, 'tasks', id);
+          batch.update(ref, { order: index, updatedAt: serverTimestamp() });
+        }
+      });
+      await batch.commit();
+    },
+    [user, tasksByColumn]
+  );
+
   return {
     statuses,
     tasksByColumn,
     loading: tasksLoading || statusesLoading,
     moveTask,
+    reorderColumns,
+    reorderTasksInColumn,
   };
 }

--- a/src/features/projects/DraggableProjectList.module.css
+++ b/src/features/projects/DraggableProjectList.module.css
@@ -1,0 +1,102 @@
+.projectsList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.projectItem {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.projectItem:hover {
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.projectItem.activeProject {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.activeProject .projectName {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.projectItem.dragging {
+  opacity: 0.35;
+}
+
+.dragHandle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-tertiary);
+  cursor: grab;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  flex-shrink: 0;
+  touch-action: none;
+}
+
+.projectItem:hover .dragHandle {
+  opacity: 1;
+}
+
+.dragHandle:active {
+  cursor: grabbing;
+}
+
+.projectDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.projectName {
+  flex: 1;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+}
+
+.projectEditBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  color: var(--text-tertiary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  opacity: 0;
+  flex-shrink: 0;
+}
+
+.projectItem:hover .projectEditBtn {
+  opacity: 1;
+}
+
+.projectEditBtn:hover {
+  background: rgba(0, 0, 0, 0.05);
+  color: var(--text-primary);
+}
+
+.projectsEmpty {
+  padding: 0.5rem 0.75rem;
+  font-size: 0.8rem;
+  color: var(--text-tertiary);
+  font-style: italic;
+}

--- a/src/features/projects/DraggableProjectList.tsx
+++ b/src/features/projects/DraggableProjectList.tsx
@@ -1,0 +1,164 @@
+import { useState } from 'react';
+import {
+  DndContext,
+  DragEndEvent,
+  DragOverlay,
+  DragStartEvent,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { GripVertical, MoreHorizontal } from 'lucide-react';
+import clsx from 'clsx';
+import { Project, PROJECT_COLORS } from '../../shared/types/task';
+import styles from './DraggableProjectList.module.css';
+
+function getProjectHex(color: string) {
+  return PROJECT_COLORS.find((c) => c.name === color)?.hex || '#86868b';
+}
+
+interface ProjectRowProps {
+  project: Project;
+  isActive: boolean;
+  onSelect: () => void;
+  onEdit: (e: React.MouseEvent) => void;
+  isOverlay?: boolean;
+}
+
+function ProjectRow({ project, isActive, onSelect, onEdit, isOverlay }: ProjectRowProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: project.id,
+    disabled: isOverlay,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className={clsx(
+        styles.projectItem,
+        isActive && styles.activeProject,
+        isDragging && styles.dragging
+      )}
+      data-testid={`project-item-${project.id}`}
+    >
+      <span
+        className={styles.dragHandle}
+        {...listeners}
+        {...attributes}
+        title="Drag to reorder"
+      >
+        <GripVertical size={14} />
+      </span>
+      <span
+        className={styles.projectDot}
+        style={{ backgroundColor: getProjectHex(project.color) }}
+      />
+      <span className={styles.projectName} onClick={onSelect}>
+        {project.title}
+      </span>
+      <button
+        className={styles.projectEditBtn}
+        onClick={onEdit}
+        title="Edit Project"
+      >
+        <MoreHorizontal size={14} />
+      </button>
+    </li>
+  );
+}
+
+interface DraggableProjectListProps {
+  projects: Project[];
+  activeProjectId: string | null;
+  onSelectProject: (id: string | null) => void;
+  onEditProject: (project: Project) => void;
+  onReorder: (orderedIds: string[]) => void;
+}
+
+export function DraggableProjectList({
+  projects,
+  activeProjectId,
+  onSelectProject,
+  onEditProject,
+  onReorder,
+}: DraggableProjectListProps) {
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
+  );
+
+  const handleDragStart = (event: DragStartEvent) => {
+    setDraggingId(event.active.id as string);
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    setDraggingId(null);
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = projects.findIndex((p) => p.id === active.id);
+    const newIndex = projects.findIndex((p) => p.id === over.id);
+    const reordered = arrayMove(projects, oldIndex, newIndex);
+    onReorder(reordered.map((p) => p.id));
+  };
+
+  const draggingProject = draggingId ? projects.find((p) => p.id === draggingId) : null;
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext items={projects.map((p) => p.id)} strategy={verticalListSortingStrategy}>
+        <ul className={styles.projectsList}>
+          {projects.map((project) => (
+            <ProjectRow
+              key={project.id}
+              project={project}
+              isActive={activeProjectId === project.id}
+              onSelect={() =>
+                onSelectProject(activeProjectId === project.id ? null : project.id)
+              }
+              onEdit={(e) => {
+                e.stopPropagation();
+                onEditProject(project);
+              }}
+            />
+          ))}
+          {projects.length === 0 && (
+            <li className={styles.projectsEmpty}>No projects yet</li>
+          )}
+        </ul>
+      </SortableContext>
+
+      <DragOverlay dropAnimation={null}>
+        {draggingProject ? (
+          <ProjectRow
+            project={draggingProject}
+            isActive={activeProjectId === draggingProject.id}
+            onSelect={() => {}}
+            onEdit={() => {}}
+            isOverlay
+          />
+        ) : null}
+      </DragOverlay>
+    </DndContext>
+  );
+}

--- a/src/features/projects/hooks/useProjects.ts
+++ b/src/features/projects/hooks/useProjects.ts
@@ -22,6 +22,7 @@ const convertProject = (docSnap: any): Project => {
     id: docSnap.id,
     title: data.title,
     color: data.color || 'emerald',
+    order: data.order ?? 0,
     createdAt: data.createdAt?.toDate().toISOString() || new Date().toISOString(),
   };
 };
@@ -96,7 +97,7 @@ export function useProjects() {
     }
 
     const projectsRef = collection(db, 'users', user.uid, 'projects');
-    const q = query(projectsRef, orderBy('createdAt', 'asc'));
+    const q = query(projectsRef, orderBy('order', 'asc'));
 
     const unsubscribe = onSnapshot(q,
       (snapshot) => {
@@ -114,5 +115,22 @@ export function useProjects() {
     return () => unsubscribe();
   }, [user]);
 
-  return { projects, loading, error, addProject, updateProject, deleteProject };
+  /**
+   * Persists a new project display order to Firestore.
+   * Writes a single WriteBatch assigning each project `order = index` (0-based).
+   * IMPORTANT: Only writes the `order` field — never touches projectId,
+   * kanbanStatusId, or any task documents. Task-to-project associations are
+   * preserved entirely.
+   */
+  const reorderProjects = async (orderedIds: string[]) => {
+    if (!user) return;
+    const batch = writeBatch(db);
+    orderedIds.forEach((id, index) => {
+      const ref = doc(db, 'users', user.uid, 'projects', id);
+      batch.update(ref, { order: index });
+    });
+    await batch.commit();
+  };
+
+  return { projects, loading, error, addProject, updateProject, deleteProject, reorderProjects };
 }

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -27,7 +27,7 @@ export function MainLayout() {
   const [projectToEdit, setProjectToEdit] = useState<Project | null>(null);
   
   const { addTask, updateTask } = useTasks(null);
-  const { projects, addProject, updateProject, deleteProject } = useProjects();
+  const { projects, addProject, updateProject, deleteProject, reorderProjects } = useProjects();
 
   const openNewTaskModal = () => {
     setTaskToEdit(null);
@@ -84,6 +84,7 @@ export function MainLayout() {
           onEditProject={handleEditProject}
           activeProjectId={activeProjectId}
           setActiveProjectId={setActiveProjectId}
+          onReorderProjects={reorderProjects}
         />
       </aside>
       

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -1,9 +1,10 @@
 import { Link, useLocation } from 'react-router-dom';
-import { Inbox, Sun, Calendar, Layers, Archive, PlusCircle, FolderPlus, MoreHorizontal, CheckSquare, Sparkles, Settings as SettingsIcon, LayoutDashboard } from 'lucide-react';
+import { Inbox, Sun, Calendar, Layers, Archive, PlusCircle, FolderPlus, CheckSquare, Sparkles, Settings as SettingsIcon, LayoutDashboard } from 'lucide-react';
 import clsx from 'clsx';
 import styles from './Sidebar.module.css';
 import { SeedButton } from '../dev/SeedButton';
-import { Project, PROJECT_COLORS } from '../shared/types/task';
+import { Project } from '../shared/types/task';
+import { DraggableProjectList } from '../features/projects/DraggableProjectList';
 
 const NAV_ITEMS = [
   { path: '/inbox', label: 'Inbox', icon: Inbox, color: 'text-secondary' },
@@ -23,14 +24,11 @@ interface SidebarProps {
   onEditProject?: (project: Project) => void;
   activeProjectId?: string | null;
   setActiveProjectId?: (id: string | null) => void;
+  onReorderProjects?: (orderedIds: string[]) => void;
 }
 
-export function Sidebar({ onNewTask, projects = [], onNewProject, onEditProject, activeProjectId, setActiveProjectId }: SidebarProps) {
+export function Sidebar({ onNewTask, projects = [], onNewProject, onEditProject, activeProjectId, setActiveProjectId, onReorderProjects }: SidebarProps) {
   const location = useLocation();
-
-  const getProjectHex = (color: string) => {
-    return PROJECT_COLORS.find(c => c.name === color)?.hex || '#86868b';
-  };
 
   return (
     <aside className={styles.sidebar}>
@@ -81,35 +79,13 @@ export function Sidebar({ onNewTask, projects = [], onNewProject, onEditProject,
             <FolderPlus size={16} />
           </button>
         </div>
-        <ul className={styles.projectsList}>
-          {projects.map((project) => (
-            <li 
-              key={project.id} 
-              className={clsx(styles.projectItem, activeProjectId === project.id && styles.activeProject)}
-              data-testid={`project-item-${project.id}`}
-              onClick={() => setActiveProjectId?.(activeProjectId === project.id ? null : project.id)}
-            >
-              <span
-                className={styles.projectDot}
-                style={{ backgroundColor: getProjectHex(project.color) }}
-              />
-              <span className={styles.projectName}>{project.title}</span>
-              <button
-                className={styles.projectEditBtn}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onEditProject?.(project);
-                }}
-                title="Edit Project"
-              >
-                <MoreHorizontal size={14} />
-              </button>
-            </li>
-          ))}
-          {projects.length === 0 && (
-            <li className={styles.projectsEmpty}>No projects yet</li>
-          )}
-        </ul>
+        <DraggableProjectList
+          projects={projects}
+          activeProjectId={activeProjectId ?? null}
+          onSelectProject={(id) => setActiveProjectId?.(id)}
+          onEditProject={(project) => onEditProject?.(project)}
+          onReorder={(orderedIds) => onReorderProjects?.(orderedIds)}
+        />
       </div>
 
       <div className={styles.actionGroup}>

--- a/src/shared/types/task.ts
+++ b/src/shared/types/task.ts
@@ -47,5 +47,6 @@ export interface Project {
   id: string;
   title: string;
   color: ProjectColor;
+  order?: number;
   createdAt?: string;
 }


### PR DESCRIPTION
…, and tasks

- Add reorderProjects() to useProjects with Firestore WriteBatch; fix query to orderBy('order') so sidebar reflects persisted priority sequence
- Add order field to Project type and convertProject mapper
- New DraggableProjectList component (dnd-kit/sortable, DragOverlay, GripVertical handle) replacing the static project list in Sidebar
- Wire reorderProjects through MainLayout → Sidebar → DraggableProjectList
- Extend useKanbanBoard with reorderColumns() (delegates to reorderStatuses) and reorderTasksInColumn() (WriteBatch on order field only)
- Sort tasks within tasksByColumn by order field so intra-column order persists across page reloads
- KanbanColumn: add useSortable for column drag handle + SortableContext wrapping task list for intra-column card sorting
- KanbanCard: switch useDraggable → useSortable with type/columnId data attrs
- KanbanBoard: add horizontalListSortingStrategy SortableContext for columns, type-tagged onDragEnd branching (column / same-column task / cross-column task), ColumnGhost DragOverlay for column drags
- Add JSDoc invariant comments confirming no task associations are mutated by any reorder operation