### PR TITLE
fix: store completedAt as ISO string so dashboard stats query matches

### DIFF
--- a/src/features/kanban/hooks/useKanbanBoard.ts
+++ b/src/features/kanban/hooks/useKanbanBoard.ts
@@ -106,7 +106,7 @@ export function useKanbanBoard(projectId: string | null) {
         if (destinationStatus.isFinal) {
           await updateDoc(taskRef, {
             status: 'completed',
-            completedAt: serverTimestamp(),
+            completedAt: new Date().toISOString(),
             kanbanStatusId: toStatusId,
             updatedAt: serverTimestamp(),
           });


### PR DESCRIPTION
useDashboardStats queries completedAt >= ISO string. Using serverTimestamp() wrote a Firestore Timestamp, which is a different type and always fails string comparison in Firestore ordering. Now uses new Date().toISOString() consistent with how useTasks.ts writes completedAt everywhere else.