### PR TITLE
feat: add project closure tracking with summary report

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { Login } from './pages/Login';
 import { AIBriefing } from './pages/AIBriefing';
 import { Settings } from './pages/Settings';
 import { Kanban } from './pages/Kanban';
+import { ClosedProjectView } from './pages/ClosedProjectView';
 
 function App() {
   return (
@@ -38,6 +39,7 @@ function App() {
               <Route path="/kanban" element={<Kanban />} />
               <Route path="/briefing" element={<AIBriefing />} />
               <Route path="/settings" element={<Settings />} />
+              <Route path="/project/:id/closed" element={<ClosedProjectView />} />
               <Route path="*" element={<Navigate to="/" replace />} />
             </Route>
           </Routes>

--- a/src/features/projects/ProjectClosureModal.module.css
+++ b/src/features/projects/ProjectClosureModal.module.css
@@ -1,0 +1,265 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 9998;
+  backdrop-filter: blur(4px);
+}
+
+.modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  z-index: 9999;
+  background: var(--bg-paper);
+  border-radius: 16px;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+  width: 480px;
+  max-width: 90vw;
+  max-height: 80vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.headerLeft {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.projectDot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.headerTitle {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: -0.02em;
+}
+
+.closeBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  color: var(--text-secondary);
+  transition: all 0.15s ease;
+  cursor: pointer;
+  background: none;
+  border: none;
+}
+
+.closeBtn:hover {
+  background: rgba(0, 0, 0, 0.05);
+  color: var(--text-primary);
+}
+
+.body {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.loading {
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  text-align: center;
+  padding: 2rem 0;
+}
+
+.statsRow {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.stat {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0.75rem 0.5rem;
+  background: var(--bg-app);
+  border-radius: 10px;
+  border: 1px solid var(--border-subtle);
+  gap: 0.25rem;
+}
+
+.statNumber {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  line-height: 1;
+}
+
+.statLabel {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.statCompleted .statNumber {
+  color: var(--accent-emerald);
+}
+
+.statCanceled .statNumber {
+  color: var(--text-tertiary);
+}
+
+.statOpen .statNumber {
+  color: var(--accent-gold);
+}
+
+.reassignSection {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.reassignHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.reassignTitle {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.moveAllBtn {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--accent-sapphire);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  border-radius: 6px;
+  transition: background 0.15s ease;
+}
+
+.moveAllBtn:hover {
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.taskList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.taskRow {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--bg-app);
+  border-radius: 8px;
+  border: 1px solid var(--border-subtle);
+}
+
+.taskTitle {
+  flex: 1;
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.projectSelect {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  background: var(--bg-paper);
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  font-family: var(--font-sans);
+  max-width: 150px;
+  flex-shrink: 0;
+}
+
+.noOpenTasks {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  text-align: center;
+  padding: 0.25rem 0;
+  margin: 0;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 1rem 1.5rem;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.cancelBtn {
+  padding: 0.6rem 1.25rem;
+  border-radius: 10px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: none;
+  border: 1px solid var(--border-subtle);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.cancelBtn:hover {
+  background: var(--bg-app);
+  color: var(--text-primary);
+}
+
+.confirmBtn {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1.25rem;
+  border-radius: 10px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: white;
+  background: var(--text-primary);
+  border: none;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.confirmBtn:hover:not(:disabled) {
+  opacity: 0.85;
+}
+
+.confirmBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}

--- a/src/features/projects/ProjectClosureModal.tsx
+++ b/src/features/projects/ProjectClosureModal.tsx
@@ -1,0 +1,199 @@
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { motion, AnimatePresence } from 'framer-motion';
+import { X, Archive } from 'lucide-react';
+import { collection, query, where, getDocs } from 'firebase/firestore';
+import { db } from '../../lib/firebase';
+import { useAuth } from '../../lib/auth/AuthContext';
+import { Project, Task, PROJECT_COLORS } from '../../shared/types/task';
+import styles from './ProjectClosureModal.module.css';
+
+function getProjectHex(color: string) {
+  return PROJECT_COLORS.find(c => c.name === color)?.hex || '#86868b';
+}
+
+function convertTask(docSnap: any): Task {
+  const data = docSnap.data();
+  return {
+    id: docSnap.id,
+    title: data.title,
+    status: data.status,
+    createdAt: data.createdAt?.toDate().toISOString() || new Date().toISOString(),
+    updatedAt: data.updatedAt?.toDate().toISOString(),
+    completedAt: data.completedAt,
+    projectId: data.projectId,
+    notes: data.notes,
+    date: data.date,
+    energy: data.energy,
+    tags: data.tags,
+    priority: data.priority,
+  };
+}
+
+interface ProjectClosureModalProps {
+  isOpen: boolean;
+  project: Project;
+  activeProjects: Project[];
+  onConfirm: (reassignments: Record<string, string | null>) => Promise<void>;
+  onCancel: () => void;
+}
+
+export function ProjectClosureModal({ isOpen, project, activeProjects, onConfirm, onCancel }: ProjectClosureModalProps) {
+  const { user } = useAuth();
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [reassignments, setReassignments] = useState<Record<string, string | null>>({});
+  const [loading, setLoading] = useState(true);
+  const [confirming, setConfirming] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen || !user) return;
+    setLoading(true);
+    const fetchTasks = async () => {
+      try {
+        const tasksRef = collection(db, 'users', user.uid, 'tasks');
+        const q = query(tasksRef, where('projectId', '==', project.id));
+        const snap = await getDocs(q);
+        const fetched = snap.docs.map(convertTask);
+        setTasks(fetched);
+        const initial: Record<string, string | null> = {};
+        fetched
+          .filter(t => t.status === 'todo' || t.status === 'someday')
+          .forEach(t => { initial[t.id] = null; });
+        setReassignments(initial);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchTasks();
+  }, [isOpen, user, project.id]);
+
+  const openTasks = tasks.filter(t => t.status === 'todo' || t.status === 'someday');
+  const completedCount = tasks.filter(t => t.status === 'completed').length;
+  const canceledCount = tasks.filter(t => t.status === 'canceled').length;
+
+  const handleConfirm = async () => {
+    setConfirming(true);
+    try {
+      await onConfirm(reassignments);
+    } finally {
+      setConfirming(false);
+    }
+  };
+
+  const moveAllToInbox = () => {
+    const updated: Record<string, string | null> = {};
+    openTasks.forEach(t => { updated[t.id] = null; });
+    setReassignments(prev => ({ ...prev, ...updated }));
+  };
+
+  return createPortal(
+    <AnimatePresence>
+      {isOpen && (
+        <>
+          <motion.div
+            className={styles.backdrop}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={onCancel}
+          />
+          <motion.div
+            className={styles.modal}
+            style={{ x: '-50%', y: '-50%' }}
+            initial={{ opacity: 0, scale: 0.95 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.95 }}
+            transition={{ type: 'spring', duration: 0.4, bounce: 0.15 }}
+          >
+            <div className={styles.header}>
+              <div className={styles.headerLeft}>
+                <span className={styles.projectDot} style={{ backgroundColor: getProjectHex(project.color) }} />
+                <span className={styles.headerTitle}>Close "{project.title}"?</span>
+              </div>
+              <button className={styles.closeBtn} onClick={onCancel}>
+                <X size={18} />
+              </button>
+            </div>
+
+            <div className={styles.body}>
+              {loading ? (
+                <div className={styles.loading}>Loading tasks...</div>
+              ) : (
+                <>
+                  <div className={styles.statsRow}>
+                    <div className={styles.stat}>
+                      <span className={styles.statNumber}>{tasks.length}</span>
+                      <span className={styles.statLabel}>Total</span>
+                    </div>
+                    <div className={`${styles.stat} ${styles.statCompleted}`}>
+                      <span className={styles.statNumber}>{completedCount}</span>
+                      <span className={styles.statLabel}>Completed</span>
+                    </div>
+                    <div className={`${styles.stat} ${styles.statCanceled}`}>
+                      <span className={styles.statNumber}>{canceledCount}</span>
+                      <span className={styles.statLabel}>Canceled</span>
+                    </div>
+                    {openTasks.length > 0 && (
+                      <div className={`${styles.stat} ${styles.statOpen}`}>
+                        <span className={styles.statNumber}>{openTasks.length}</span>
+                        <span className={styles.statLabel}>Open</span>
+                      </div>
+                    )}
+                  </div>
+
+                  {openTasks.length > 0 ? (
+                    <div className={styles.reassignSection}>
+                      <div className={styles.reassignHeader}>
+                        <span className={styles.reassignTitle}>Reassign open tasks</span>
+                        <button className={styles.moveAllBtn} onClick={moveAllToInbox}>
+                          Move all to Inbox
+                        </button>
+                      </div>
+                      <div className={styles.taskList}>
+                        {openTasks.map(task => (
+                          <div key={task.id} className={styles.taskRow}>
+                            <span className={styles.taskTitle}>{task.title}</span>
+                            <select
+                              className={styles.projectSelect}
+                              value={reassignments[task.id] ?? ''}
+                              onChange={e => setReassignments(prev => ({
+                                ...prev,
+                                [task.id]: e.target.value || null,
+                              }))}
+                            >
+                              <option value="">No project (Inbox)</option>
+                              {activeProjects.map(p => (
+                                <option key={p.id} value={p.id}>{p.title}</option>
+                              ))}
+                            </select>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ) : (
+                    <p className={styles.noOpenTasks}>
+                      All tasks are completed or canceled — ready to close.
+                    </p>
+                  )}
+                </>
+              )}
+            </div>
+
+            <div className={styles.footer}>
+              <button className={styles.cancelBtn} onClick={onCancel}>Cancel</button>
+              <button
+                className={styles.confirmBtn}
+                onClick={handleConfirm}
+                disabled={loading || confirming}
+              >
+                <Archive size={14} />
+                {confirming ? 'Closing…' : 'Close Project'}
+              </button>
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>,
+    document.body
+  );
+}

--- a/src/features/projects/ProjectModal.module.css
+++ b/src/features/projects/ProjectModal.module.css
@@ -173,6 +173,27 @@
   opacity: 1;
 }
 
+.closeProjectBtn {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1rem;
+  border-radius: 10px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: none;
+  border: 1px solid var(--border-subtle);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.closeProjectBtn:hover {
+  background: var(--bg-app);
+  color: var(--text-primary);
+  border-color: var(--text-secondary);
+}
+
 .spacer {
   flex: 1;
 }

--- a/src/features/projects/ProjectModal.tsx
+++ b/src/features/projects/ProjectModal.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'framer-motion';
-import { X, Check, Trash2 } from 'lucide-react';
+import { X, Check, Trash2, Archive } from 'lucide-react';
 import clsx from 'clsx';
 import { Project, PROJECT_COLORS, ProjectColor } from '../../shared/types/task';
 import styles from './ProjectModal.module.css';
@@ -11,10 +11,11 @@ interface ProjectModalProps {
   onClose: () => void;
   onSave: (title: string, color: ProjectColor) => Promise<void>;
   onDelete?: (id: string) => Promise<void>;
+  onCloseProject?: () => void;
   initialData?: Project | null;
 }
 
-export function ProjectModal({ isOpen, onClose, onSave, onDelete, initialData }: ProjectModalProps) {
+export function ProjectModal({ isOpen, onClose, onSave, onDelete, onCloseProject, initialData }: ProjectModalProps) {
   const [title, setTitle] = useState('');
   const [color, setColor] = useState<ProjectColor>('emerald');
 
@@ -121,6 +122,11 @@ export function ProjectModal({ isOpen, onClose, onSave, onDelete, initialData }:
               {initialData && onDelete && (
                 <button className={styles.deleteBtn} onClick={handleDelete} data-testid="btn-delete-project">
                   <Trash2 size={14} /> Delete
+                </button>
+              )}
+              {initialData && onCloseProject && (
+                <button className={styles.closeProjectBtn} onClick={() => { onClose(); onCloseProject(); }} data-testid="btn-close-project">
+                  <Archive size={14} /> Close
                 </button>
               )}
               <div className={styles.spacer} />

--- a/src/features/projects/hooks/useProjects.ts
+++ b/src/features/projects/hooks/useProjects.ts
@@ -10,7 +10,8 @@ import {
   serverTimestamp,
   getDocs,
   where,
-  writeBatch
+  writeBatch,
+  deleteField
 } from 'firebase/firestore';
 import { db } from '../../../lib/firebase';
 import { useAuth } from '../../../lib/auth/AuthContext';
@@ -24,12 +25,14 @@ const convertProject = (docSnap: any): Project => {
     color: data.color || 'emerald',
     order: data.order ?? 0,
     createdAt: data.createdAt?.toDate().toISOString() || new Date().toISOString(),
+    status: data.status,
+    closedAt: data.closedAt,
   };
 };
 
 export function useProjects() {
   const { user } = useAuth();
-  const [projects, setProjects] = useState<Project[]>([]);
+  const [allProjects, setAllProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -39,7 +42,7 @@ export function useProjects() {
       const ref = await addDoc(collection(db, 'users', user.uid, 'projects'), {
         title,
         color,
-        order: projects.length,
+        order: allProjects.filter(p => p.status !== 'closed').length,
         createdAt: serverTimestamp(),
         updatedAt: serverTimestamp(),
       });
@@ -102,7 +105,7 @@ export function useProjects() {
     const unsubscribe = onSnapshot(q,
       (snapshot) => {
         const fetchedProjects = snapshot.docs.map(convertProject);
-        setProjects(fetchedProjects);
+        setAllProjects(fetchedProjects);
         setLoading(false);
       },
       (err) => {
@@ -115,13 +118,6 @@ export function useProjects() {
     return () => unsubscribe();
   }, [user]);
 
-  /**
-   * Persists a new project display order to Firestore.
-   * Writes a single WriteBatch assigning each project `order = index` (0-based).
-   * IMPORTANT: Only writes the `order` field — never touches projectId,
-   * kanbanStatusId, or any task documents. Task-to-project associations are
-   * preserved entirely.
-   */
   const reorderProjects = async (orderedIds: string[]) => {
     if (!user) return;
     const batch = writeBatch(db);
@@ -132,5 +128,49 @@ export function useProjects() {
     await batch.commit();
   };
 
-  return { projects, loading, error, addProject, updateProject, deleteProject, reorderProjects };
+  const closeProject = async (id: string, reassignments: Record<string, string | null>) => {
+    if (!user) return;
+    try {
+      const batch = writeBatch(db);
+      Object.entries(reassignments).forEach(([taskId, newProjectId]) => {
+        const taskRef = doc(db, 'users', user.uid, 'tasks', taskId);
+        batch.update(taskRef, { projectId: newProjectId ?? null, updatedAt: serverTimestamp() });
+      });
+      const projectRef = doc(db, 'users', user.uid, 'projects', id);
+      batch.update(projectRef, {
+        status: 'closed',
+        closedAt: new Date().toISOString(),
+        updatedAt: serverTimestamp(),
+      });
+      await batch.commit();
+    } catch (e) {
+      console.error('Error closing project', e);
+      throw e;
+    }
+  };
+
+  const reopenProject = async (id: string) => {
+    if (!user) return;
+    try {
+      const projectRef = doc(db, 'users', user.uid, 'projects', id);
+      await updateDoc(projectRef, {
+        status: 'active',
+        closedAt: deleteField(),
+        updatedAt: serverTimestamp(),
+      });
+    } catch (e) {
+      console.error('Error reopening project', e);
+      throw e;
+    }
+  };
+
+  const projects = allProjects.filter(p => p.status !== 'closed');
+  const closedProjects = allProjects
+    .filter(p => p.status === 'closed')
+    .sort((a, b) => {
+      if (!a.closedAt || !b.closedAt) return 0;
+      return b.closedAt.localeCompare(a.closedAt);
+    });
+
+  return { projects, closedProjects, loading, error, addProject, updateProject, deleteProject, reorderProjects, closeProject, reopenProject };
 }

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet, useNavigate } from 'react-router-dom';
 import { Sidebar } from './Sidebar';
 import { BottomNav } from './BottomNav';
 import styles from './MainLayout.module.css';
@@ -9,6 +9,7 @@ import { useTasks } from '../features/tasks/hooks/useTasks';
 import { useProjects } from '../features/projects/hooks/useProjects';
 import { TaskEditorModal } from '../features/tasks/TaskEditorModal';
 import { ProjectModal } from '../features/projects/ProjectModal';
+import { ProjectClosureModal } from '../features/projects/ProjectClosureModal';
 import { Plus, X, PanelLeftOpen } from 'lucide-react';
 import clsx from 'clsx';
 import { Task, Project, ProjectColor } from '../shared/types/task';
@@ -22,6 +23,7 @@ export type MainLayoutContext = {
 };
 
 export function MainLayout() {
+  const navigate = useNavigate();
   const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(
     () => localStorage.getItem('sidebar-collapsed') === 'true'
   );
@@ -30,9 +32,10 @@ export function MainLayout() {
   const [taskToEdit, setTaskToEdit] = useState<Task | null>(null);
   const [isProjectModalOpen, setIsProjectModalOpen] = useState(false);
   const [projectToEdit, setProjectToEdit] = useState<Project | null>(null);
-  
+  const [isClosureModalOpen, setIsClosureModalOpen] = useState(false);
+
   const { addTask, updateTask } = useTasks(null);
-  const { projects, addProject, updateProject, deleteProject, reorderProjects } = useProjects();
+  const { projects, closedProjects, addProject, updateProject, deleteProject, reorderProjects, closeProject } = useProjects();
   const { importError: calendarImportError } = useGoogleCalendarImport();
   const [calendarBannerDismissed, setCalendarBannerDismissed] = useState(false);
 
@@ -89,12 +92,32 @@ export function MainLayout() {
     await deleteProject(id);
   };
 
+  const handleInitiateClose = () => {
+    setIsProjectModalOpen(false);
+    setIsClosureModalOpen(true);
+  };
+
+  const handleConfirmClosure = async (reassignments: Record<string, string | null>) => {
+    if (!projectToEdit) return;
+    const closingId = projectToEdit.id;
+    await closeProject(closingId, reassignments);
+    if (activeProjectId === closingId) setActiveProjectId(null);
+    setIsClosureModalOpen(false);
+    setProjectToEdit(null);
+    navigate(`/project/${closingId}/closed`);
+  };
+
+  const handleCancelClosure = () => {
+    setIsClosureModalOpen(false);
+  };
+
   return (
     <div className={styles.layout}>
       <aside className={styles.sidebarWrapper}>
         <Sidebar
           onNewTask={openNewTaskModal}
           projects={projects}
+          closedProjects={closedProjects}
           onNewProject={handleOpenNewProject}
           onEditProject={handleEditProject}
           activeProjectId={activeProjectId}
@@ -158,8 +181,19 @@ export function MainLayout() {
         onClose={() => setIsProjectModalOpen(false)}
         onSave={handleSaveProject}
         onDelete={handleDeleteProject}
+        onCloseProject={handleInitiateClose}
         initialData={projectToEdit}
       />
+
+      {projectToEdit && (
+        <ProjectClosureModal
+          isOpen={isClosureModalOpen}
+          project={projectToEdit}
+          activeProjects={projects}
+          onConfirm={handleConfirmClosure}
+          onCancel={handleCancelClosure}
+        />
+      )}
     </div>
   );
 }

--- a/src/layout/Sidebar.module.css
+++ b/src/layout/Sidebar.module.css
@@ -304,3 +304,92 @@
   color: var(--text-tertiary);
   font-style: italic;
 }
+
+/* Closed projects section */
+.closedSection {
+  margin-top: 0.75rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.closedSectionToggle {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  width: 100%;
+  padding: 0.375rem 0.75rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-tertiary);
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  border-radius: 6px;
+  transition: color 0.15s ease;
+  text-align: left;
+}
+
+.closedSectionToggle:hover {
+  color: var(--text-secondary);
+}
+
+.closedCount {
+  margin-left: auto;
+  background: var(--bg-app);
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  padding: 0.05rem 0.4rem;
+  font-size: 0.65rem;
+  font-weight: 600;
+  color: var(--text-tertiary);
+}
+
+.closedList {
+  list-style: none;
+  padding: 0;
+  margin: 0.25rem 0 0;
+}
+
+.closedItem {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: 8px;
+  color: var(--text-tertiary);
+  font-weight: 400;
+  text-decoration: none;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.closedItem:hover {
+  background: rgba(0, 0, 0, 0.03);
+  color: var(--text-secondary);
+}
+
+.closedItemActive {
+  background: rgba(0, 0, 0, 0.05);
+  color: var(--text-secondary);
+}
+
+.closedDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.closedName {
+  flex: 1;
+  font-size: 0.8rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.closedIcon {
+  flex-shrink: 0;
+  opacity: 0.5;
+}

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -1,10 +1,15 @@
 import { Link, useLocation } from 'react-router-dom';
-import { Inbox, Sun, Calendar, Layers, Archive, PlusCircle, FolderPlus, CheckSquare, Sparkles, Settings as SettingsIcon, LayoutDashboard, PanelLeftClose } from 'lucide-react';
+import { useState } from 'react';
+import { Inbox, Sun, Calendar, Layers, Archive, PlusCircle, FolderPlus, CheckSquare, Sparkles, Settings as SettingsIcon, LayoutDashboard, PanelLeftClose, ChevronRight, ChevronDown } from 'lucide-react';
 import clsx from 'clsx';
 import styles from './Sidebar.module.css';
 import { SeedButton } from '../dev/SeedButton';
-import { Project } from '../shared/types/task';
+import { Project, PROJECT_COLORS } from '../shared/types/task';
 import { DraggableProjectList } from '../features/projects/DraggableProjectList';
+
+function getProjectHex(color: string) {
+  return PROJECT_COLORS.find(c => c.name === color)?.hex || '#86868b';
+}
 
 const NAV_ITEMS = [
   { path: '/inbox', label: 'Inbox', icon: Inbox, color: 'text-secondary' },
@@ -20,6 +25,7 @@ const NAV_ITEMS = [
 interface SidebarProps {
   onNewTask?: () => void;
   projects?: Project[];
+  closedProjects?: Project[];
   onNewProject?: () => void;
   onEditProject?: (project: Project) => void;
   activeProjectId?: string | null;
@@ -29,8 +35,9 @@ interface SidebarProps {
   onToggleSidebar?: () => void;
 }
 
-export function Sidebar({ onNewTask, projects = [], onNewProject, onEditProject, activeProjectId, setActiveProjectId, onReorderProjects, collapsed, onToggleSidebar }: SidebarProps) {
+export function Sidebar({ onNewTask, projects = [], closedProjects = [], onNewProject, onEditProject, activeProjectId, setActiveProjectId, onReorderProjects, collapsed, onToggleSidebar }: SidebarProps) {
   const location = useLocation();
+  const [closedExpanded, setClosedExpanded] = useState(false);
 
   return (
     <aside className={clsx(styles.sidebar, collapsed && styles.collapsed)}>
@@ -99,6 +106,42 @@ export function Sidebar({ onNewTask, projects = [], onNewProject, onEditProject,
           onEditProject={(project) => onEditProject?.(project)}
           onReorder={(orderedIds) => onReorderProjects?.(orderedIds)}
         />
+
+        {closedProjects.length > 0 && (
+          <div className={styles.closedSection}>
+            <button
+              className={styles.closedSectionToggle}
+              onClick={() => setClosedExpanded(prev => !prev)}
+            >
+              {closedExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+              <span>Closed</span>
+              <span className={styles.closedCount}>{closedProjects.length}</span>
+            </button>
+            {closedExpanded && (
+              <ul className={styles.closedList}>
+                {closedProjects.map(project => {
+                  const isActive = location.pathname === `/project/${project.id}/closed`;
+                  return (
+                    <li key={project.id}>
+                      <Link
+                        to={`/project/${project.id}/closed`}
+                        className={clsx(styles.closedItem, isActive && styles.closedItemActive)}
+                        onClick={() => setActiveProjectId?.(null)}
+                      >
+                        <span
+                          className={styles.closedDot}
+                          style={{ backgroundColor: getProjectHex(project.color), opacity: 0.5 }}
+                        />
+                        <span className={styles.closedName}>{project.title}</span>
+                        <Archive size={11} className={styles.closedIcon} />
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        )}
       </div>
 
       <div className={styles.actionGroup}>

--- a/src/lib/types/firestore.ts
+++ b/src/lib/types/firestore.ts
@@ -24,4 +24,6 @@ export interface ProjectDocument {
   title: string;
   color: string;
   order: number;
+  status?: 'active' | 'closed';
+  closedAt?: string;
 }

--- a/src/pages/ClosedProjectView.module.css
+++ b/src/pages/ClosedProjectView.module.css
@@ -1,0 +1,228 @@
+.container {
+  padding: 2rem;
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+.loadingText {
+  color: var(--text-secondary);
+  padding: 2rem;
+  text-align: center;
+}
+
+.header {
+  margin-bottom: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.titleRow {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.projectDot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.title {
+  font-size: 1.875rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0;
+  letter-spacing: -0.02em;
+}
+
+.closedBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.25rem 0.625rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  background: var(--bg-app);
+  border: 1px solid var(--border-subtle);
+  letter-spacing: 0.02em;
+}
+
+.subtitle {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  margin: 0;
+}
+
+.reopenBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  padding: 0.55rem 1.1rem;
+  border-radius: 10px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: none;
+  border: 1px solid var(--border-subtle);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  width: fit-content;
+}
+
+.reopenBtn:hover:not(:disabled) {
+  background: var(--bg-app);
+  color: var(--text-primary);
+}
+
+.reopenBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.statsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1rem;
+  margin-bottom: 2.5rem;
+}
+
+.statCard {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 1.25rem 1rem;
+  background: var(--bg-paper);
+  border-radius: 12px;
+  border: 1px solid var(--border-subtle);
+  gap: 0.375rem;
+}
+
+.statCardGreen .statValue {
+  color: var(--accent-emerald);
+}
+
+.statValue {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  line-height: 1;
+  letter-spacing: -0.03em;
+}
+
+.statLabel {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  text-align: center;
+}
+
+.section {
+  margin-bottom: 2rem;
+}
+
+.sectionTitle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 0.875rem 0;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.iconCompleted {
+  color: var(--accent-emerald);
+}
+
+.iconCanceled {
+  color: var(--text-tertiary);
+}
+
+.iconOpen {
+  color: var(--accent-gold);
+}
+
+.taskList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.taskItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.625rem 0.875rem;
+  background: var(--bg-paper);
+  border-radius: 8px;
+  border: 1px solid var(--border-subtle);
+}
+
+.taskCanceled {
+  opacity: 0.6;
+}
+
+.taskOpen {
+  opacity: 0.75;
+}
+
+.taskName {
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  flex: 1;
+}
+
+.taskMeta {
+  font-size: 0.775rem;
+  color: var(--text-tertiary);
+  font-weight: 500;
+  flex-shrink: 0;
+  margin-left: 0.75rem;
+}
+
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 4rem 2rem;
+  color: var(--text-secondary);
+  background: var(--bg-paper);
+  border-radius: 12px;
+  border: 1px dashed var(--border-subtle);
+  gap: 1rem;
+}
+
+.emptyIcon {
+  opacity: 0.4;
+}
+
+.emptyState p {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--text-secondary);
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding: 1.5rem 1rem;
+  }
+
+  .statsGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}

--- a/src/pages/ClosedProjectView.tsx
+++ b/src/pages/ClosedProjectView.tsx
@@ -1,0 +1,234 @@
+import { useState, useEffect, useMemo } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { collection, query, where, getDocs, doc, getDoc, updateDoc, serverTimestamp, deleteField } from 'firebase/firestore';
+import { Archive, RotateCcw, CheckCircle2, XCircle, Circle } from 'lucide-react';
+import { db } from '../lib/firebase';
+import { useAuth } from '../lib/auth/AuthContext';
+import { Project, Task, PROJECT_COLORS } from '../shared/types/task';
+import styles from './ClosedProjectView.module.css';
+
+function getProjectHex(color: string) {
+  return PROJECT_COLORS.find(c => c.name === color)?.hex || '#86868b';
+}
+
+function convertTask(docSnap: any): Task {
+  const data = docSnap.data();
+  return {
+    id: docSnap.id,
+    title: data.title,
+    status: data.status,
+    createdAt: data.createdAt?.toDate().toISOString() || new Date().toISOString(),
+    updatedAt: data.updatedAt?.toDate().toISOString(),
+    completedAt: data.completedAt,
+    projectId: data.projectId,
+    notes: data.notes,
+    date: data.date,
+    energy: data.energy,
+    tags: data.tags,
+    priority: data.priority,
+  };
+}
+
+export function ClosedProjectView() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [project, setProject] = useState<Project | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [reopening, setReopening] = useState(false);
+
+  useEffect(() => {
+    if (!user || !id) return;
+    const fetchData = async () => {
+      try {
+        const projectRef = doc(db, 'users', user.uid, 'projects', id);
+        const projectSnap = await getDoc(projectRef);
+        if (!projectSnap.exists()) {
+          navigate('/', { replace: true });
+          return;
+        }
+        const data = projectSnap.data();
+        setProject({
+          id: projectSnap.id,
+          title: data.title,
+          color: data.color || 'emerald',
+          order: data.order ?? 0,
+          createdAt: data.createdAt?.toDate().toISOString() || new Date().toISOString(),
+          status: data.status,
+          closedAt: data.closedAt,
+        });
+
+        const tasksRef = collection(db, 'users', user.uid, 'tasks');
+        const q = query(tasksRef, where('projectId', '==', id));
+        const tasksSnap = await getDocs(q);
+        setTasks(tasksSnap.docs.map(convertTask));
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [user, id, navigate]);
+
+  const stats = useMemo(() => {
+    const completed = tasks.filter(t => t.status === 'completed');
+    const canceled = tasks.filter(t => t.status === 'canceled');
+    const open = tasks.filter(t => t.status === 'todo' || t.status === 'someday');
+    const total = tasks.length;
+    const completionRate = total > 0 ? Math.round((completed.length / total) * 100) : 0;
+
+    const withTimes = completed.filter(t => t.completedAt && t.createdAt);
+    const avgDays = withTimes.length > 0
+      ? Math.round(
+          withTimes.reduce((sum, t) => {
+            const days = (new Date(t.completedAt!).getTime() - new Date(t.createdAt).getTime()) / (1000 * 60 * 60 * 24);
+            return sum + days;
+          }, 0) / withTimes.length
+        )
+      : null;
+
+    const createdAt = project?.createdAt ? new Date(project.createdAt) : null;
+    const closedAt = project?.closedAt ? new Date(project.closedAt) : null;
+    const duration = createdAt && closedAt
+      ? Math.ceil((closedAt.getTime() - createdAt.getTime()) / (1000 * 60 * 60 * 24))
+      : null;
+
+    return { completed, canceled, open, total, completionRate, avgDays, duration };
+  }, [tasks, project]);
+
+  const handleReopen = async () => {
+    if (!id || !user) return;
+    setReopening(true);
+    try {
+      const projectRef = doc(db, 'users', user.uid, 'projects', id);
+      await updateDoc(projectRef, {
+        status: 'active',
+        closedAt: deleteField(),
+        updatedAt: serverTimestamp(),
+      });
+      navigate('/', { replace: true });
+    } catch (e) {
+      console.error('Error reopening project', e);
+      setReopening(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className={styles.container}>
+        <p className={styles.loadingText}>Loading…</p>
+      </div>
+    );
+  }
+
+  if (!project) return null;
+
+  const closedDateLabel = project.closedAt
+    ? new Date(project.closedAt).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })
+    : null;
+
+  return (
+    <div className={styles.container}>
+      <header className={styles.header}>
+        <div className={styles.titleRow}>
+          <span className={styles.projectDot} style={{ backgroundColor: getProjectHex(project.color) }} />
+          <h1 className={styles.title}>{project.title}</h1>
+          <span className={styles.closedBadge}>
+            <Archive size={11} />
+            Closed
+          </span>
+        </div>
+        {closedDateLabel && (
+          <p className={styles.subtitle}>Closed on {closedDateLabel}</p>
+        )}
+        <button className={styles.reopenBtn} onClick={handleReopen} disabled={reopening}>
+          <RotateCcw size={14} />
+          {reopening ? 'Reopening…' : 'Reopen Project'}
+        </button>
+      </header>
+
+      <div className={styles.statsGrid}>
+        {stats.duration !== null && (
+          <div className={styles.statCard}>
+            <span className={styles.statValue}>{stats.duration}</span>
+            <span className={styles.statLabel}>Days open</span>
+          </div>
+        )}
+        <div className={styles.statCard}>
+          <span className={styles.statValue}>{stats.total}</span>
+          <span className={styles.statLabel}>Total tasks</span>
+        </div>
+        <div className={`${styles.statCard} ${styles.statCardGreen}`}>
+          <span className={styles.statValue}>{stats.completionRate}%</span>
+          <span className={styles.statLabel}>Completion rate</span>
+        </div>
+        {stats.avgDays !== null && (
+          <div className={styles.statCard}>
+            <span className={styles.statValue}>{stats.avgDays}</span>
+            <span className={styles.statLabel}>Avg days/task</span>
+          </div>
+        )}
+      </div>
+
+      {stats.completed.length > 0 && (
+        <section className={styles.section}>
+          <h2 className={styles.sectionTitle}>
+            <CheckCircle2 size={15} className={styles.iconCompleted} />
+            Completed ({stats.completed.length})
+          </h2>
+          <ul className={styles.taskList}>
+            {stats.completed.map(task => (
+              <li key={task.id} className={styles.taskItem}>
+                <span className={styles.taskName}>{task.title}</span>
+                {task.completedAt && (
+                  <span className={styles.taskMeta}>
+                    {new Date(task.completedAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {stats.canceled.length > 0 && (
+        <section className={styles.section}>
+          <h2 className={styles.sectionTitle}>
+            <XCircle size={15} className={styles.iconCanceled} />
+            Canceled ({stats.canceled.length})
+          </h2>
+          <ul className={styles.taskList}>
+            {stats.canceled.map(task => (
+              <li key={task.id} className={`${styles.taskItem} ${styles.taskCanceled}`}>
+                <span className={styles.taskName}>{task.title}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {stats.open.length > 0 && (
+        <section className={styles.section}>
+          <h2 className={styles.sectionTitle}>
+            <Circle size={15} className={styles.iconOpen} />
+            Still open ({stats.open.length})
+          </h2>
+          <ul className={styles.taskList}>
+            {stats.open.map(task => (
+              <li key={task.id} className={`${styles.taskItem} ${styles.taskOpen}`}>
+                <span className={styles.taskName}>{task.title}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {stats.total === 0 && (
+        <div className={styles.emptyState}>
+          <Archive size={40} className={styles.emptyIcon} />
+          <p>No tasks were recorded for this project.</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/shared/types/task.ts
+++ b/src/shared/types/task.ts
@@ -52,4 +52,6 @@ export interface Project {
   color: ProjectColor;
   order?: number;
   createdAt?: string;
+  status?: 'active' | 'closed';
+  closedAt?: string;
 }


### PR DESCRIPTION
Adds the ability to close projects and view a read-only closure report
showing task metrics, completion rate, and average days per task.

- Extends Project model with status ('active'|'closed') and closedAt fields
- Adds closeProject() + reopenProject() to useProjects hook
- ProjectModal gets a 'Close' button that opens ProjectClosureModal
- ProjectClosureModal shows task breakdown and prompts to reassign open
  tasks to other projects or inbox before confirming closure
- ClosedProjectView (/project/:id/closed) shows duration, completion rate,
  avg days/task, and lists of completed/canceled/open tasks
- Sidebar shows a collapsible 'Closed' section with all archived projects
- Reopening a project restores it to the active list

https://claude.ai/code/session_01NjmPaNXB3rtxKJFopSwecF