### PR TITLE
feat: project closure tracking with summary report and mobile support

### DIFF
--- a/src/features/projects/DraggableProjectList.module.css
+++ b/src/features/projects/DraggableProjectList.module.css
@@ -94,6 +94,13 @@
   color: var(--text-primary);
 }
 
+@media (max-width: 768px) {
+  .projectEditBtn,
+  .dragHandle {
+    opacity: 1;
+  }
+}
+
 .projectsEmpty {
   padding: 0.5rem 0.75rem;
   font-size: 0.8rem;

--- a/src/features/projects/ProjectClosureModal.tsx
+++ b/src/features/projects/ProjectClosureModal.tsx
@@ -9,7 +9,7 @@ import { Project, Task, PROJECT_COLORS } from '../../shared/types/task';
 import styles from './ProjectClosureModal.module.css';
 
 function getProjectHex(color: string) {
-  return PROJECT_COLORS.find(c => c.name === color)?.hex || '#86868b';
+  return PROJECT_COLORS.find(c => c.name === color)?.hex || 'var(--text-secondary)';
 }
 
 function convertTask(docSnap: any): Task {

--- a/src/features/projects/ProjectModal.module.css
+++ b/src/features/projects/ProjectModal.module.css
@@ -149,6 +149,27 @@
   gap: 0.75rem;
   padding: 1rem 1.5rem;
   border-top: 1px solid var(--border-subtle);
+  flex-wrap: wrap;
+}
+
+@media (max-width: 480px) {
+  .footer {
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+
+  .spacer {
+    display: none;
+  }
+
+  .saveBtn,
+  .cancelBtn,
+  .closeProjectBtn,
+  .deleteBtn {
+    width: 100%;
+    justify-content: center;
+    text-align: center;
+  }
 }
 
 .deleteBtn {

--- a/src/layout/MainLayout.module.css
+++ b/src/layout/MainLayout.module.css
@@ -94,22 +94,53 @@
   box-shadow: var(--shadow-md);
 }
 
+.mobileMenuBtn {
+  display: none;
+  position: fixed;
+  top: 12px;
+  left: 12px;
+  z-index: 998;
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  background-color: var(--bg-paper);
+  border: 1px solid var(--border-subtle);
+  color: var(--text-secondary);
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  box-shadow: var(--shadow-sm);
+}
+
+.mobileOverlay {
+  display: none;
+}
+
 /* Mobile Responsive */
 @media (max-width: 768px) {
   .mainContent {
     margin-left: 0;
-    padding-bottom: 80px; /* Space for bottom nav if needed */
+    padding-bottom: 80px;
   }
 
-  .sidebarWrapper {
-    display: none;
-  }
-  
   .fab {
-    display: flex; /* Show FAB on mobile */
+    display: flex;
   }
 
   .expandButton {
     display: none;
+  }
+
+  .mobileMenuBtn {
+    display: flex;
+  }
+
+  .mobileOverlay {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    z-index: 1099;
   }
 }

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -10,7 +10,7 @@ import { useProjects } from '../features/projects/hooks/useProjects';
 import { TaskEditorModal } from '../features/tasks/TaskEditorModal';
 import { ProjectModal } from '../features/projects/ProjectModal';
 import { ProjectClosureModal } from '../features/projects/ProjectClosureModal';
-import { Plus, X, PanelLeftOpen } from 'lucide-react';
+import { Plus, X, PanelLeftOpen, Menu } from 'lucide-react';
 import clsx from 'clsx';
 import { Task, Project, ProjectColor } from '../shared/types/task';
 
@@ -33,6 +33,7 @@ export function MainLayout() {
   const [isProjectModalOpen, setIsProjectModalOpen] = useState(false);
   const [projectToEdit, setProjectToEdit] = useState<Project | null>(null);
   const [isClosureModalOpen, setIsClosureModalOpen] = useState(false);
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
 
   const { addTask, updateTask } = useTasks(null);
   const { projects, closedProjects, addProject, updateProject, deleteProject, reorderProjects, closeProject } = useProjects();
@@ -125,6 +126,8 @@ export function MainLayout() {
           onReorderProjects={reorderProjects}
           collapsed={sidebarCollapsed}
           onToggleSidebar={toggleSidebar}
+          mobileOpen={mobileSidebarOpen}
+          onMobileClose={() => setMobileSidebarOpen(false)}
         />
       </aside>
       
@@ -136,6 +139,21 @@ export function MainLayout() {
         >
           <PanelLeftOpen size={18} />
         </button>
+      )}
+
+      <button
+        className={styles.mobileMenuBtn}
+        onClick={() => setMobileSidebarOpen(true)}
+        aria-label="Open menu"
+      >
+        <Menu size={20} />
+      </button>
+
+      {mobileSidebarOpen && (
+        <div
+          className={styles.mobileOverlay}
+          onClick={() => setMobileSidebarOpen(false)}
+        />
       )}
 
       <main className={clsx(styles.mainContent, sidebarCollapsed && styles.mainContentExpanded)}>

--- a/src/layout/Sidebar.module.css
+++ b/src/layout/Sidebar.module.css
@@ -13,10 +13,15 @@
   transition: transform 0.3s ease-in-out;
 }
 
-/* Mobile: Hide by default or off-canvas */
+/* Mobile: off-canvas by default, slides in when .mobileOpen */
 @media (max-width: 768px) {
   .sidebar {
     transform: translateX(-100%);
+    z-index: 1100;
+  }
+
+  .sidebar.mobileOpen {
+    transform: translateX(0);
   }
 }
 

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -33,14 +33,16 @@ interface SidebarProps {
   onReorderProjects?: (orderedIds: string[]) => void;
   collapsed?: boolean;
   onToggleSidebar?: () => void;
+  mobileOpen?: boolean;
+  onMobileClose?: () => void;
 }
 
-export function Sidebar({ onNewTask, projects = [], closedProjects = [], onNewProject, onEditProject, activeProjectId, setActiveProjectId, onReorderProjects, collapsed, onToggleSidebar }: SidebarProps) {
+export function Sidebar({ onNewTask, projects = [], closedProjects = [], onNewProject, onEditProject, activeProjectId, setActiveProjectId, onReorderProjects, collapsed, onToggleSidebar, mobileOpen, onMobileClose }: SidebarProps) {
   const location = useLocation();
   const [closedExpanded, setClosedExpanded] = useState(false);
 
   return (
-    <aside className={clsx(styles.sidebar, collapsed && styles.collapsed)}>
+    <aside className={clsx(styles.sidebar, collapsed && styles.collapsed, mobileOpen && styles.mobileOpen)}>
       <div className={styles.header}>
         <div className={styles.headerRow}>
           <div className={styles.logo}>Arre</div>
@@ -69,9 +71,8 @@ export function Sidebar({ onNewTask, projects = [], closedProjects = [], onNewPr
                   className={clsx(styles.navItem, isActive && styles.active)}
                   data-testid={`nav-item-${item.label.toLowerCase().replace(/\s+/g, '-')}`}
                   onClick={() => {
-                    if (item.path === '/inbox') {
-                      setActiveProjectId?.(null);
-                    }
+                    if (item.path === '/inbox') setActiveProjectId?.(null);
+                    onMobileClose?.();
                   }}
                 >
                   <span className={clsx(styles.iconWrapper, isActive && styles[item.color])}>
@@ -102,7 +103,7 @@ export function Sidebar({ onNewTask, projects = [], closedProjects = [], onNewPr
         <DraggableProjectList
           projects={projects}
           activeProjectId={activeProjectId ?? null}
-          onSelectProject={(id) => setActiveProjectId?.(id)}
+          onSelectProject={(id) => { setActiveProjectId?.(id); onMobileClose?.(); }}
           onEditProject={(project) => onEditProject?.(project)}
           onReorder={(orderedIds) => onReorderProjects?.(orderedIds)}
         />
@@ -126,7 +127,7 @@ export function Sidebar({ onNewTask, projects = [], closedProjects = [], onNewPr
                       <Link
                         to={`/project/${project.id}/closed`}
                         className={clsx(styles.closedItem, isActive && styles.closedItemActive)}
-                        onClick={() => setActiveProjectId?.(null)}
+                        onClick={() => { setActiveProjectId?.(null); onMobileClose?.(); }}
                       >
                         <span
                           className={styles.closedDot}

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -8,7 +8,7 @@ import { Project, PROJECT_COLORS } from '../shared/types/task';
 import { DraggableProjectList } from '../features/projects/DraggableProjectList';
 
 function getProjectHex(color: string) {
-  return PROJECT_COLORS.find(c => c.name === color)?.hex || '#86868b';
+  return PROJECT_COLORS.find(c => c.name === color)?.hex || 'var(--text-secondary)';
 }
 
 const NAV_ITEMS = [

--- a/src/pages/ClosedProjectView.tsx
+++ b/src/pages/ClosedProjectView.tsx
@@ -8,7 +8,7 @@ import { Project, Task, PROJECT_COLORS } from '../shared/types/task';
 import styles from './ClosedProjectView.module.css';
 
 function getProjectHex(color: string) {
-  return PROJECT_COLORS.find(c => c.name === color)?.hex || '#86868b';
+  return PROJECT_COLORS.find(c => c.name === color)?.hex || 'var(--text-secondary)';
 }
 
 function convertTask(docSnap: any): Task {


### PR DESCRIPTION
## Summary

- **Close projects** from the edit modal — a guided closure flow prompts reassignment of any open tasks to other projects or inbox before confirming
- **Closure report** (`/project/:id/closed`) shows duration, total tasks, completion rate %, avg days per task, and lists of completed/canceled/open tasks with a Reopen button
- **Closed projects section** in the sidebar — collapsible list below active projects, each linking to its report
- **Mobile access** — hamburger button slides the sidebar in on mobile; project edit button is always visible on touch screens; modal footer stacks vertically on narrow screens

## Test plan

- [ ] Create a project with a mix of completed, canceled, and open tasks
- [ ] Open the project modal → tap **Close** → verify task counts are correct
- [ ] Reassign open tasks or use "Move all to Inbox", then confirm
- [ ] Confirm the project disappears from the active list and appears in the **Closed** section of the sidebar
- [ ] Click the closed project → verify the report shows correct duration, completion rate, and avg days
- [ ] Tap **Reopen Project** → confirm it moves back to the active list
- [ ] On mobile: tap the hamburger (☰) at top-left → sidebar slides in → tap a project edit button (always visible) → **Close** button is visible in the modal footer
- [ ] Existing projects without a `status` field continue to appear as active (backwards compat)

https://claude.ai/code/session_01NjmPaNXB3rtxKJFopSwecF

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjmPaNXB3rtxKJFopSwecF)_