### PR TITLE
fix: task counts show 0 and tasks appear unassociated after project c…

### DIFF
--- a/src/features/projects/ProjectClosureModal.tsx
+++ b/src/features/projects/ProjectClosureModal.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { X, Archive } from 'lucide-react';
-import { collection, query, where, getDocs } from 'firebase/firestore';
+import { collection, query, where, onSnapshot } from 'firebase/firestore';
 import { db } from '../../lib/firebase';
 import { useAuth } from '../../lib/auth/AuthContext';
 import { Project, Task, PROJECT_COLORS } from '../../shared/types/task';
@@ -48,23 +48,30 @@ export function ProjectClosureModal({ isOpen, project, activeProjects, onConfirm
   useEffect(() => {
     if (!isOpen || !user) return;
     setLoading(true);
-    const fetchTasks = async () => {
-      try {
-        const tasksRef = collection(db, 'users', user.uid, 'tasks');
-        const q = query(tasksRef, where('projectId', '==', project.id));
-        const snap = await getDocs(q);
-        const fetched = snap.docs.map(convertTask);
+    const tasksRef = collection(db, 'users', user.uid, 'tasks');
+    const q = query(tasksRef, where('projectId', '==', project.id));
+
+    const unsubscribe = onSnapshot(
+      q,
+      (snapshot) => {
+        const fetched = snapshot.docs.map(convertTask);
         setTasks(fetched);
-        const initial: Record<string, string | null> = {};
-        fetched
-          .filter(t => t.status === 'todo' || t.status === 'someday')
-          .forEach(t => { initial[t.id] = null; });
-        setReassignments(initial);
-      } finally {
+        setReassignments(prev => {
+          const next: Record<string, string | null> = {};
+          fetched
+            .filter(t => t.status === 'todo' || t.status === 'someday')
+            .forEach(t => { next[t.id] = prev[t.id] ?? null; });
+          return next;
+        });
+        setLoading(false);
+      },
+      (err) => {
+        console.error('Error fetching project tasks for closure:', err);
         setLoading(false);
       }
-    };
-    fetchTasks();
+    );
+
+    return () => unsubscribe();
   }, [isOpen, user, project.id]);
 
   const openTasks = tasks.filter(t => t.status === 'todo' || t.status === 'someday');

--- a/src/features/tasks/TaskItem.tsx
+++ b/src/features/tasks/TaskItem.tsx
@@ -14,7 +14,7 @@ interface TaskItemProps {
 
 export function TaskItem({ task, onToggle }: TaskItemProps) {
   const [complete, setComplete] = useState(task.status === 'completed');
-  const { openEditTaskModal, projects } = useOutletContext<MainLayoutContext>();
+  const { openEditTaskModal, projects, closedProjects } = useOutletContext<MainLayoutContext>();
   const { deleteTask } = useTasks();
 
   const handleToggle = () => {
@@ -35,8 +35,9 @@ export function TaskItem({ task, onToggle }: TaskItemProps) {
     openEditTaskModal(task);
   };
 
+  const allProjects = [...(projects ?? []), ...(closedProjects ?? [])];
   const project = task.projectId
-    ? projects?.find((p: Project) => p.id === task.projectId)
+    ? allProjects.find((p: Project) => p.id === task.projectId)
     : null;
 
   const getProjectHex = (color: string) =>

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -18,6 +18,7 @@ export type MainLayoutContext = {
   openNewTaskModal: () => void;
   openEditTaskModal: (task: Task) => void;
   projects: Project[];
+  closedProjects: Project[];
   activeProjectId: string | null;
   setActiveProjectId: (id: string | null) => void;
 };
@@ -170,7 +171,7 @@ export function MainLayout() {
           </div>
         )}
         <div className={styles.container}>
-          <Outlet context={{ openNewTaskModal, openEditTaskModal, projects, activeProjectId, setActiveProjectId } satisfies MainLayoutContext} />
+          <Outlet context={{ openNewTaskModal, openEditTaskModal, projects, closedProjects, activeProjectId, setActiveProjectId } satisfies MainLayoutContext} />
         </div>
       </main>
 

--- a/src/pages/ClosedProjectView.tsx
+++ b/src/pages/ClosedProjectView.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { collection, query, where, getDocs, doc, getDoc, updateDoc, serverTimestamp, deleteField } from 'firebase/firestore';
+import { collection, query, where, onSnapshot, doc, getDoc, updateDoc, serverTimestamp, deleteField } from 'firebase/firestore';
 import { Archive, RotateCcw, CheckCircle2, XCircle, Circle } from 'lucide-react';
 import { db } from '../lib/firebase';
 import { useAuth } from '../lib/auth/AuthContext';
@@ -40,34 +40,39 @@ export function ClosedProjectView() {
 
   useEffect(() => {
     if (!user || !id) return;
-    const fetchData = async () => {
-      try {
-        const projectRef = doc(db, 'users', user.uid, 'projects', id);
-        const projectSnap = await getDoc(projectRef);
-        if (!projectSnap.exists()) {
-          navigate('/', { replace: true });
-          return;
-        }
-        const data = projectSnap.data();
-        setProject({
-          id: projectSnap.id,
-          title: data.title,
-          color: data.color || 'emerald',
-          order: data.order ?? 0,
-          createdAt: data.createdAt?.toDate().toISOString() || new Date().toISOString(),
-          status: data.status,
-          closedAt: data.closedAt,
-        });
 
-        const tasksRef = collection(db, 'users', user.uid, 'tasks');
-        const q = query(tasksRef, where('projectId', '==', id));
-        const tasksSnap = await getDocs(q);
-        setTasks(tasksSnap.docs.map(convertTask));
-      } finally {
+    // Fetch project doc once
+    const projectRef = doc(db, 'users', user.uid, 'projects', id);
+    getDoc(projectRef).then((snap) => {
+      if (!snap.exists()) { navigate('/', { replace: true }); return; }
+      const data = snap.data();
+      setProject({
+        id: snap.id,
+        title: data.title,
+        color: data.color || 'emerald',
+        order: data.order ?? 0,
+        createdAt: data.createdAt?.toDate().toISOString() || new Date().toISOString(),
+        status: data.status,
+        closedAt: data.closedAt,
+      });
+    }).catch(err => console.error('Error fetching closed project:', err));
+
+    // Subscribe to tasks for this project
+    const tasksRef = collection(db, 'users', user.uid, 'tasks');
+    const q = query(tasksRef, where('projectId', '==', id));
+    const unsubscribe = onSnapshot(
+      q,
+      (snapshot) => {
+        setTasks(snapshot.docs.map(convertTask));
+        setLoading(false);
+      },
+      (err) => {
+        console.error('Error fetching tasks for closed project:', err);
         setLoading(false);
       }
-    };
-    fetchData();
+    );
+
+    return () => unsubscribe();
   }, [user, id, navigate]);
 
   const stats = useMemo(() => {


### PR DESCRIPTION
…lose

Bug 1 — Closure modal always showed 0 counts:
  getDocs was wrapped in try/finally with no catch, so any Firestore
  error (index, network, permission) was silently swallowed and tasks
  stayed as []. Replaced with onSnapshot (the codebase pattern) which
  surfaces errors to the console and retries on transient failures.
  Same fix applied to ClosedProjectView task fetch.

Bug 2 — Logbook tasks lost project badge after closing:
  TaskItem looked up the project via projects from MainLayoutContext,
  which is now active-only. After closing, the project is filtered out
  so the badge disappeared even though projectId in Firestore was intact.
  Added closedProjects to MainLayoutContext and updated TaskItem to
  search both lists when resolving the project badge.

https://claude.ai/code/session_01NjmPaNXB3rtxKJFopSwecF