### PR TITLE
Add collapsible projects section and project-aware navigation

### DIFF
--- a/src/layout/Sidebar.module.css
+++ b/src/layout/Sidebar.module.css
@@ -201,8 +201,25 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.5rem 0.75rem;
+  padding: 0.25rem 0.75rem;
   margin-bottom: 0.25rem;
+}
+
+.projectsToggle {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-tertiary);
+  padding: 0.25rem 0;
+  border-radius: 4px;
+  transition: color 0.15s ease;
+}
+
+.projectsToggle:hover {
+  color: var(--text-secondary);
 }
 
 .projectsTitle {
@@ -210,7 +227,7 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--text-tertiary);
+  color: inherit;
 }
 
 .addProjectBtn {

--- a/src/layout/Sidebar.module.css
+++ b/src/layout/Sidebar.module.css
@@ -208,13 +208,13 @@
 .projectsToggle {
   display: flex;
   align-items: center;
-  gap: 0.35rem;
+  gap: 0.25rem;
   background: none;
   border: none;
   cursor: pointer;
   color: var(--text-tertiary);
   padding: 0.25rem 0;
-  border-radius: 4px;
+  border-radius: 6px;
   transition: color 0.15s ease;
 }
 

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 import { Inbox, Sun, Calendar, Layers, Archive, PlusCircle, FolderPlus, CheckSquare, Sparkles, Settings as SettingsIcon, LayoutDashboard, PanelLeftClose, ChevronRight, ChevronDown } from 'lucide-react';
 import clsx from 'clsx';
@@ -40,7 +40,9 @@ interface SidebarProps {
 
 export function Sidebar({ onNewTask, projects = [], closedProjects = [], onNewProject, onEditProject, activeProjectId, setActiveProjectId, onReorderProjects, collapsed, onToggleSidebar, mobileOpen, onMobileClose }: SidebarProps) {
   const location = useLocation();
+  const navigate = useNavigate();
   const [closedExpanded, setClosedExpanded] = useState(false);
+  const [projectsExpanded, setProjectsExpanded] = useState(true);
   const { isVisible } = useNavVisibility();
 
   return (
@@ -92,7 +94,14 @@ export function Sidebar({ onNewTask, projects = [], closedProjects = [], onNewPr
       {/* Projects Section */}
       <div className={styles.projectsSection}>
         <div className={styles.projectsHeader}>
-          <span className={styles.projectsTitle}>Projects</span>
+          <button
+            className={styles.projectsToggle}
+            onClick={() => setProjectsExpanded(prev => !prev)}
+            aria-label={projectsExpanded ? 'Collapse projects' : 'Expand projects'}
+          >
+            {projectsExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+            <span className={styles.projectsTitle}>Projects</span>
+          </button>
           <button
             className={styles.addProjectBtn}
             onClick={onNewProject}
@@ -102,13 +111,23 @@ export function Sidebar({ onNewTask, projects = [], closedProjects = [], onNewPr
             <FolderPlus size={16} />
           </button>
         </div>
-        <DraggableProjectList
-          projects={projects}
-          activeProjectId={activeProjectId ?? null}
-          onSelectProject={(id) => { setActiveProjectId?.(id); onMobileClose?.(); }}
-          onEditProject={(project) => onEditProject?.(project)}
-          onReorder={(orderedIds) => onReorderProjects?.(orderedIds)}
-        />
+        {projectsExpanded && (
+          <DraggableProjectList
+            projects={projects}
+            activeProjectId={activeProjectId ?? null}
+            onSelectProject={(id) => {
+              if (id) {
+                setActiveProjectId?.(id);
+                navigate('/kanban', { state: { projectId: id } });
+              } else {
+                setActiveProjectId?.(null);
+              }
+              onMobileClose?.();
+            }}
+            onEditProject={(project) => onEditProject?.(project)}
+            onReorder={(orderedIds) => onReorderProjects?.(orderedIds)}
+          />
+        )}
 
         {closedProjects.length > 0 && (
           <div className={styles.closedSection}>

--- a/src/pages/Kanban.tsx
+++ b/src/pages/Kanban.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useOutletContext } from 'react-router-dom';
+import { useOutletContext, useLocation } from 'react-router-dom';
 import { LayoutDashboard, FolderPlus, Settings2 } from 'lucide-react';
 import { MainLayoutContext } from '../layout/MainLayout';
 import { KanbanBoard } from '../features/kanban/KanbanBoard';
@@ -8,11 +8,24 @@ import styles from './Kanban.module.css';
 export function Kanban() {
   const { projects, openEditTaskModal, onNewProject, onEditProject, reorderProjects } =
     useOutletContext<MainLayoutContext>();
+  const location = useLocation();
+
+  const getInitialProjectId = () => {
+    const stateId = (location.state as { projectId?: string } | null)?.projectId;
+    if (stateId && projects.some((p) => p.id === stateId)) return stateId;
+    return projects.length > 0 ? projects[0].id : null;
+  };
 
   // Selection is lifted here so the header buttons know the "current" project.
-  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(
-    projects.length > 0 ? projects[0].id : null
-  );
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(getInitialProjectId);
+
+  // When navigating from sidebar with a specific project, update selection.
+  useEffect(() => {
+    const stateId = (location.state as { projectId?: string } | null)?.projectId;
+    if (stateId && projects.some((p) => p.id === stateId)) {
+      setSelectedProjectId(stateId);
+    }
+  }, [location.state, projects]);
 
   // Keep the selection valid as the project list changes (deleted/closed/added).
   useEffect(() => {


### PR DESCRIPTION
## Summary
This PR adds the ability to collapse/expand the Projects section in the sidebar and improves project navigation by automatically routing to the Kanban view when selecting a project from the sidebar.

## Key Changes
- **Sidebar Projects Toggle**: Added a collapsible Projects section with a chevron icon that toggles visibility of the project list
- **Project-Aware Navigation**: When selecting a project from the sidebar, the app now navigates to `/kanban` with the selected project ID passed via router state
- **Kanban Initial State**: Updated the Kanban page to respect the project ID from navigation state, allowing direct project selection from the sidebar
- **Styling Updates**: Adjusted padding and added hover states for the new projects toggle button

## Implementation Details
- Added `useNavigate` hook to Sidebar for routing to Kanban view
- Introduced `projectsExpanded` state to track Projects section visibility
- Modified `onSelectProject` callback to navigate to `/kanban` with `{ state: { projectId: id } }`
- Updated Kanban component to read initial project ID from `location.state` and sync selection when navigation state changes
- Added `.projectsToggle` button styles with chevron icons (ChevronDown/ChevronRight) for visual feedback
- Maintained backward compatibility with existing project selection logic

https://claude.ai/code/session_018YRFW5dJhbfdCCekxkP7Ua