### PR TITLE
Add configurable default landing page in Settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,20 @@ import { ClosedProjectView } from './pages/ClosedProjectView';
 import { NavVisibilityProvider, useNavVisibility } from './features/navigation/NavVisibilityProvider';
 import { NAV_ITEMS } from './layout/Sidebar';
 
+export const DEFAULT_PAGE_KEY = 'default-page';
+
+function RootRoute() {
+  const hasChecked = sessionStorage.getItem('default-page-checked');
+  if (!hasChecked) {
+    sessionStorage.setItem('default-page-checked', '1');
+    const pref = localStorage.getItem(DEFAULT_PAGE_KEY);
+    if (pref && pref !== '/') {
+      return <Navigate to={pref} replace />;
+    }
+  }
+  return <Dashboard />;
+}
+
 function RedirectIfHidden() {
   const location = useLocation();
   const navigate = useNavigate();
@@ -51,7 +65,7 @@ function App() {
                 <MainLayout />
               </ProtectedRoute>
             }>
-              <Route path="/" element={<Dashboard />} />
+              <Route path="/" element={<RootRoute />} />
               <Route path="/inbox" element={<Inbox />} />
               <Route path="/upcoming" element={<Upcoming />} />
               <Route path="/anytime" element={<Anytime />} />

--- a/src/pages/Settings.module.css
+++ b/src/pages/Settings.module.css
@@ -279,6 +279,27 @@
   font-style: normal;
 }
 
+.selectControl {
+  padding: var(--spacing-2) var(--spacing-3);
+  border-radius: 8px;
+  border: 1px solid var(--border-subtle);
+  background-color: var(--bg-app);
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  cursor: pointer;
+  min-width: 140px;
+  transition: border-color 0.15s ease;
+}
+
+.selectControl:hover {
+  border-color: var(--border-color);
+}
+
+.selectControl:focus {
+  outline: none;
+  border-color: var(--accent-sapphire);
+}
+
 .navToggleList {
   display: flex;
   flex-direction: column;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,4 +1,4 @@
-import { Settings as SettingsIcon, Sun, Moon, Laptop, LayoutDashboard } from 'lucide-react';
+import { Settings as SettingsIcon, Sun, Moon, Laptop, LayoutDashboard, Home } from 'lucide-react';
 import clsx from 'clsx';
 import styles from './Settings.module.css';
 import { useAuth } from '../lib/auth/AuthContext';
@@ -10,6 +10,7 @@ import { db, functions } from '../lib/firebase';
 import { httpsCallable } from 'firebase/functions';
 import { NAV_ITEMS } from '../layout/Sidebar';
 import { useNavVisibility } from '../features/navigation/NavVisibilityProvider';
+import { DEFAULT_PAGE_KEY } from '../App';
 
 interface GoogleTaskList {
   id: string;
@@ -26,6 +27,9 @@ export function Settings() {
   const { user, connectGoogleTasks, disconnectGoogleTasks, connectGoogleCalendar, disconnectGoogleCalendar } = useAuth();
   const { theme, setTheme } = useTheme();
   const { isVisible, toggleItem } = useNavVisibility();
+  const [defaultPage, setDefaultPage] = useState(
+    () => localStorage.getItem(DEFAULT_PAGE_KEY) ?? '/'
+  );
   const [isConnecting, setIsConnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isConnected, setIsConnected] = useState(false);
@@ -209,6 +213,28 @@ export function Settings() {
           <p className={styles.sectionDescription}>
             Choose which items appear in the sidebar and navigation.
           </p>
+          <div className={styles.navToggleRow}>
+            <div className={styles.navItemInfo}>
+              <Home size={16} />
+              <span>Landing page</span>
+            </div>
+            <select
+              className={styles.selectControl}
+              value={defaultPage}
+              onChange={(e) => {
+                const val = e.target.value;
+                setDefaultPage(val);
+                localStorage.setItem(DEFAULT_PAGE_KEY, val);
+              }}
+              aria-label="Default landing page"
+            >
+              {NAV_ITEMS.map((item) => (
+                <option key={item.path} value={item.path}>
+                  {item.label}
+                </option>
+              ))}
+            </select>
+          </div>
           <div className={styles.navToggleList}>
             {NAV_ITEMS.map((item) => {
               const Icon = item.icon;


### PR DESCRIPTION
- Settings → Navigation section now has a "Landing page" dropdown listing all nav items
- Selection is persisted in localStorage under 'default-page'
- On fresh app load (each new browser session), RootRoute reads the preference and redirects to the chosen page before showing Today
- Subsequent navigations to / during the same session show the Today/Dashboard page normally (sessionStorage flag prevents repeated redirects)
